### PR TITLE
Re-export anything relevant from lpc82x

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,21 @@ pub mod usart;
 pub mod wkt;
 
 
+pub use lpc82x::{
+    CPUID,
+    DCB,
+    DWT,
+    FPB,
+    FPU,
+    ITM,
+    MPU,
+    NVIC,
+    SCB,
+    SYST,
+    TPIU,
+    Interrupt,
+};
+
 pub use self::gpio::Gpio;
 pub use self::pmu::Pmu;
 pub use self::swm::Swm;


### PR DESCRIPTION
This re-exports relevant type from the lpc82x crate. Users of this crate
should not need to depend on lpc82x directly.

Close #17