### PR TITLE
Reorganize API structure

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -8,7 +8,7 @@ use lpc82x;
 use ::{
     swm,
     Pin,
-    Swm,
+    SWM,
     SYSCON,
 };
 use init_state::{
@@ -55,7 +55,7 @@ impl<'gpio> GPIO<'gpio> {
     ///
     /// Disables the fixed function of the given pin (thus making it available
     /// for GPIO) and sets the GPIO direction to output.
-    pub fn set_pin_to_output<P>(&mut self, swm: &mut Swm)
+    pub fn set_pin_to_output<P>(&mut self, swm: &mut SWM)
         where P: Pin + swm::PinExt
     {
         P::disable_fixed_functions(swm);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -9,7 +9,7 @@ use ::{
     swm,
     Pin,
     Swm,
-    Syscon,
+    SYSCON,
 };
 use init_state::{
     self,
@@ -37,7 +37,7 @@ impl<'gpio> GPIO<'gpio, init_state::Unknown> {
     }
 
     /// Initialize GPIO
-    pub fn init(mut self, syscon: &mut Syscon)
+    pub fn init(mut self, syscon: &mut SYSCON)
         -> GPIO<'gpio, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.gpio);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -7,9 +7,9 @@ use lpc82x;
 
 use ::{
     swm,
+    syscon,
     Pin,
     SWM,
-    SYSCON,
 };
 use init_state::{
     self,
@@ -37,7 +37,7 @@ impl<'gpio> GPIO<'gpio, init_state::Unknown> {
     }
 
     /// Initialize GPIO
-    pub fn init(mut self, syscon: &mut SYSCON)
+    pub fn init(mut self, syscon: &mut syscon::Api)
         -> GPIO<'gpio, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.gpio);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -23,14 +23,14 @@ use init_state::{
 /// [`lpc82x::GPIO_PORT`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::GPIO_PORT`]: ../../lpc82x/struct.GPIO_PORT.html
-pub struct Gpio<'gpio, State: InitState = init_state::Initialized> {
+pub struct GPIO<'gpio, State: InitState = init_state::Initialized> {
     gpio  : &'gpio lpc82x::GPIO_PORT,
     _state: State,
 }
 
-impl<'gpio> Gpio<'gpio, init_state::Unknown> {
+impl<'gpio> GPIO<'gpio, init_state::Unknown> {
     pub(crate) fn new(gpio: &'gpio lpc82x::GPIO_PORT) -> Self {
-        Gpio {
+        GPIO {
             gpio  : gpio,
             _state: init_state::Unknown,
         }
@@ -38,19 +38,19 @@ impl<'gpio> Gpio<'gpio, init_state::Unknown> {
 
     /// Initialize GPIO
     pub fn init(mut self, syscon: &mut Syscon)
-        -> Gpio<'gpio, init_state::Initialized>
+        -> GPIO<'gpio, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.gpio);
         syscon.clear_reset(&mut self.gpio);
 
-        Gpio {
+        GPIO {
             gpio  : self.gpio,
             _state: init_state::Initialized,
         }
     }
 }
 
-impl<'gpio> Gpio<'gpio> {
+impl<'gpio> GPIO<'gpio> {
     /// Sets pin direction to output
     ///
     /// Disables the fixed function of the given pin (thus making it available

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@
 //!
 //! // We're going to need a clock for sleeping. Let's use the IRC-derived clock
 //! // that runs at 750 kHz.
-//! let clock = system.clocks.irc_derived_clock.enable(
+//! let clock = system.peripherals.syscon.irc_derived_clock.enable(
 //!     &mut syscon,
 //!     system.peripherals.syscon.irc,
 //!     system.peripherals.syscon.ircout,
@@ -290,8 +290,7 @@ impl<'system> System<'system> {
 
         System {
             clocks: Clocks {
-                irc_derived_clock: syscon::IrcDerivedClock::new(),
-                low_power_clock  : pmu::LowPowerClock::new(),
+                low_power_clock: pmu::LowPowerClock::new(),
             },
             peripherals: Peripherals {
                 cpuid: peripherals.CPUID,
@@ -340,11 +339,6 @@ impl<'system> System<'system> {
 ///
 /// [`System`]: struct.System.html
 pub struct Clocks {
-    /// The 750 kHz IRC-derived clock
-    ///
-    /// Can be used to run the self-wake-up timer (WKT).
-    pub irc_derived_clock: syscon::IrcDerivedClock<clock::state::Disabled>,
-
     /// The 10 kHz low-power clock
     ///
     /// Can be used to run the self-wake-up timer (WKT).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub use lpc82x::{
     Interrupt,
 };
 
-pub use self::gpio::Gpio;
+pub use self::gpio::GPIO;
 pub use self::pmu::Pmu;
 pub use self::swm::Swm;
 pub use self::syscon::Syscon;
@@ -323,7 +323,7 @@ impl<'system> System<'system> {
                 spi1      : peripherals.SPI1,
                 wwdt      : peripherals.WWDT,
 
-                gpio  : Gpio::new(peripherals.GPIO_PORT),
+                gpio  : GPIO::new(peripherals.GPIO_PORT),
                 pmu   : Pmu::new(peripherals.PMU),
                 swm   : Swm::new(peripherals.SWM),
                 syscon: Syscon::new(peripherals.SYSCON),
@@ -584,7 +584,7 @@ pub struct Peripherals<'system> {
     pub wwdt: &'system lpc82x::WWDT,
 
     /// General Purpose I/O (GPIO)
-    pub gpio: Gpio<'system, init_state::Unknown>,
+    pub gpio: GPIO<'system, init_state::Unknown>,
 
     /// Power Management Unit (PMU)
     pub pmu: Pmu<'system>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,8 +153,8 @@
 //! // that runs at 750 kHz.
 //! let clock = system.clocks.irc_derived_clock.enable(
 //!     &mut syscon,
-//!     system.resources.irc,
-//!     system.resources.ircout,
+//!     system.peripherals.syscon.irc,
+//!     system.peripherals.syscon.ircout,
 //! );
 //!
 //! // Set pin direction to output, so we can use it to blink an LED.
@@ -270,9 +270,6 @@ pub struct System<'system> {
 
     /// System peripherals
     pub peripherals: Peripherals<'system>,
-
-    /// Other system resources
-    pub resources: Resources,
 }
 
 impl<'system> System<'system> {
@@ -331,18 +328,6 @@ impl<'system> System<'system> {
                 usart1: USART::new(peripherals.USART1),
                 usart2: USART::new(peripherals.USART2),
                 wkt   : WKT::new(peripherals.WKT),
-            },
-            resources: Resources {
-                bod    : syscon::BOD::new(),
-                flash  : syscon::FLASH::new(),
-                irc    : syscon::IRC::new(),
-                ircout : syscon::IRCOUT::new(),
-                mtb    : syscon::MTB::new(),
-                ram0_1 : syscon::RAM0_1::new(),
-                rom    : syscon::ROM::new(),
-                sysosc : syscon::SYSOSC::new(),
-                syspll : syscon::SYSPLL::new(),
-                uartfrg: syscon::UARTFRG::new(),
             },
         }
     }
@@ -606,44 +591,6 @@ pub struct Peripherals<'system> {
 
     /// Self-wake-up timer (WKT)
     pub wkt: WKT<'system, init_state::Unknown>,
-}
-
-
-/// Provides access to other system resources
-///
-/// This struct is part of [`System`].
-///
-/// [`System`]: struct.System.html
-pub struct Resources {
-    /// Brown-out detection
-    pub bod: syscon::BOD,
-
-    /// Flash memory
-    pub flash: syscon::FLASH,
-
-    /// IRC
-    pub irc: syscon::IRC,
-
-    /// IRC output
-    pub ircout: syscon::IRCOUT,
-
-    /// Micro Trace Buffer
-    pub mtb: syscon::MTB,
-
-    /// Random access memory
-    pub ram0_1: syscon::RAM0_1,
-
-    /// Read-only memory
-    pub rom: syscon::ROM,
-
-    /// System oscillator
-    pub sysosc: syscon::SYSOSC,
-
-    /// PLL
-    pub syspll: syscon::SYSPLL,
-
-    /// UART Fractional Baud Rate Generator
-    pub uartfrg: syscon::UARTFRG,
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ pub use lpc82x::{
 
 pub use self::gpio::GPIO;
 pub use self::pmu::Pmu;
-pub use self::swm::Swm;
+pub use self::swm::SWM;
 pub use self::syscon::SYSCON;
 pub use self::usart::USART;
 pub use self::wkt::WKT;
@@ -325,7 +325,7 @@ impl<'system> System<'system> {
 
                 gpio  : GPIO::new(peripherals.GPIO_PORT),
                 pmu   : Pmu::new(peripherals.PMU),
-                swm   : Swm::new(peripherals.SWM),
+                swm   : SWM::new(peripherals.SWM),
                 syscon: SYSCON::new(peripherals.SYSCON),
                 usart0: USART::new(peripherals.USART0),
                 usart1: USART::new(peripherals.USART1),
@@ -590,7 +590,7 @@ pub struct Peripherals<'system> {
     pub pmu: Pmu<'system>,
 
     /// Switch matrix (SWM)
-    pub swm: Swm<'system, init_state::Unknown>,
+    pub swm: SWM<'system, init_state::Unknown>,
 
     /// System configuration (SYSCON)
     pub syscon: SYSCON<'system>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ pub use self::gpio::GPIO;
 pub use self::pmu::Pmu;
 pub use self::swm::Swm;
 pub use self::syscon::Syscon;
-pub use self::usart::Usart;
+pub use self::usart::USART;
 pub use self::wkt::WKT;
 
 
@@ -327,9 +327,9 @@ impl<'system> System<'system> {
                 pmu   : Pmu::new(peripherals.PMU),
                 swm   : Swm::new(peripherals.SWM),
                 syscon: Syscon::new(peripherals.SYSCON),
-                usart0: Usart::new(peripherals.USART0),
-                usart1: Usart::new(peripherals.USART1),
-                usart2: Usart::new(peripherals.USART2),
+                usart0: USART::new(peripherals.USART0),
+                usart1: USART::new(peripherals.USART1),
+                usart2: USART::new(peripherals.USART2),
                 wkt   : WKT::new(peripherals.WKT),
             },
             resources: Resources {
@@ -596,13 +596,13 @@ pub struct Peripherals<'system> {
     pub syscon: Syscon<'system>,
 
     /// USART0
-    pub usart0: Usart<'system, lpc82x::USART0, init_state::Unknown>,
+    pub usart0: USART<'system, lpc82x::USART0, init_state::Unknown>,
 
     /// USART1
-    pub usart1: Usart<'system, lpc82x::USART1, init_state::Unknown>,
+    pub usart1: USART<'system, lpc82x::USART1, init_state::Unknown>,
 
     /// USART2
-    pub usart2: Usart<'system, lpc82x::USART2, init_state::Unknown>,
+    pub usart2: USART<'system, lpc82x::USART2, init_state::Unknown>,
 
     /// Self-wake-up timer (WKT)
     pub wkt: WKT<'system, init_state::Unknown>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub use lpc82x::{
 };
 
 pub use self::gpio::GPIO;
-pub use self::pmu::Pmu;
+pub use self::pmu::PMU;
 pub use self::swm::SWM;
 pub use self::syscon::SYSCON;
 pub use self::usart::USART;
@@ -324,7 +324,7 @@ impl<'system> System<'system> {
                 wwdt      : peripherals.WWDT,
 
                 gpio  : GPIO::new(peripherals.GPIO_PORT),
-                pmu   : Pmu::new(peripherals.PMU),
+                pmu   : PMU::new(peripherals.PMU),
                 swm   : SWM::new(peripherals.SWM),
                 syscon: SYSCON::new(peripherals.SYSCON),
                 usart0: USART::new(peripherals.USART0),
@@ -587,7 +587,7 @@ pub struct Peripherals<'system> {
     pub gpio: GPIO<'system, init_state::Unknown>,
 
     /// Power Management Unit (PMU)
-    pub pmu: Pmu<'system>,
+    pub pmu: PMU<'system>,
 
     /// Switch matrix (SWM)
     pub swm: SWM<'system, init_state::Unknown>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,7 +592,7 @@ pub struct Peripherals<'system> {
     /// Switch matrix (SWM)
     pub swm: Swm<'system, init_state::Unknown>,
 
-    /// Systeom configuration (SYSCON)
+    /// System configuration (SYSCON)
     pub syscon: SYSCON<'system>,
 
     /// USART0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ pub use self::pmu::Pmu;
 pub use self::swm::Swm;
 pub use self::syscon::Syscon;
 pub use self::usart::Usart;
-pub use self::wkt::Wkt;
+pub use self::wkt::WKT;
 
 
 /// Entry point to the HAL API
@@ -330,7 +330,7 @@ impl<'system> System<'system> {
                 usart0: Usart::new(peripherals.USART0),
                 usart1: Usart::new(peripherals.USART1),
                 usart2: Usart::new(peripherals.USART2),
-                wkt   : Wkt::new(peripherals.WKT),
+                wkt   : WKT::new(peripherals.WKT),
             },
             resources: Resources {
                 bod    : syscon::BOD::new(),
@@ -605,7 +605,7 @@ pub struct Peripherals<'system> {
     pub usart2: Usart<'system, lpc82x::USART2, init_state::Unknown>,
 
     /// Self-wake-up timer (WKT)
-    pub wkt: Wkt<'system, init_state::Unknown>,
+    pub wkt: WKT<'system, init_state::Unknown>,
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,9 +265,6 @@ pub use self::wkt::WKT;
 /// be used and instantiated freely. This is a temporary state of affairs, and
 /// work to integrate those types into this struct is impending.
 pub struct System<'system> {
-    /// System clocks
-    pub clocks: Clocks,
-
     /// System peripherals
     pub peripherals: Peripherals<'system>,
 }
@@ -289,9 +286,6 @@ impl<'system> System<'system> {
         let peripherals = lpc82x::Peripherals::all();
 
         System {
-            clocks: Clocks {
-                low_power_clock: pmu::LowPowerClock::new(),
-            },
             peripherals: Peripherals {
                 cpuid: peripherals.CPUID,
                 dcb  : peripherals.DCB,
@@ -330,19 +324,6 @@ impl<'system> System<'system> {
             },
         }
     }
-}
-
-
-/// Provides access to clocks in the system
-///
-/// This struct is part of [`System`].
-///
-/// [`System`]: struct.System.html
-pub struct Clocks {
-    /// The 10 kHz low-power clock
-    ///
-    /// Can be used to run the self-wake-up timer (WKT).
-    pub low_power_clock: pmu::LowPowerClock<clock::state::Disabled>,
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //!
 //! // Let's save some peripherals in local variables for convenience. This one
 //! // here doesn't require initialization.
-//! let mut syscon = system.peripherals.syscon;
+//! let mut syscon = system.peripherals.syscon.api;
 //!
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing it will actually lead to compile-time errors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,13 +257,6 @@ pub use self::wkt::WKT;
 /// It consists of multiple sub-structs for each category of system resource.
 ///
 /// Only one instance of this struct must exist in your program.
-///
-/// # Limitations
-///
-/// Currently not all system resources are actually available from this struct
-/// and its sub-structs. Many of them are modelled as unit-like structs that can
-/// be used and instantiated freely. This is a temporary state of affairs, and
-/// work to integrate those types into this struct is impending.
 pub struct System<'system> {
     /// System peripherals
     pub peripherals: Peripherals<'system>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ pub use lpc82x::{
 pub use self::gpio::GPIO;
 pub use self::pmu::Pmu;
 pub use self::swm::Swm;
-pub use self::syscon::Syscon;
+pub use self::syscon::SYSCON;
 pub use self::usart::USART;
 pub use self::wkt::WKT;
 
@@ -326,7 +326,7 @@ impl<'system> System<'system> {
                 gpio  : GPIO::new(peripherals.GPIO_PORT),
                 pmu   : Pmu::new(peripherals.PMU),
                 swm   : Swm::new(peripherals.SWM),
-                syscon: Syscon::new(peripherals.SYSCON),
+                syscon: SYSCON::new(peripherals.SYSCON),
                 usart0: USART::new(peripherals.USART0),
                 usart1: USART::new(peripherals.USART1),
                 usart2: USART::new(peripherals.USART2),
@@ -593,7 +593,7 @@ pub struct Peripherals<'system> {
     pub swm: Swm<'system, init_state::Unknown>,
 
     /// Systeom configuration (SYSCON)
-    pub syscon: Syscon<'system>,
+    pub syscon: SYSCON<'system>,
 
     /// USART0
     pub usart0: USART<'system, lpc82x::USART0, init_state::Unknown>,

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -26,6 +26,11 @@ use clock::state::ClockState;
 pub struct PMU<'pmu> {
     /// Main PMU API
     pub api: Api<'pmu>,
+
+    /// The 10 kHz low-power clock
+    ///
+    /// Can be used to run the self-wake-up timer (WKT).
+    pub low_power_clock: LowPowerClock<clock::state::Disabled>,
 }
 
 impl<'pmu> PMU<'pmu> {
@@ -35,6 +40,7 @@ impl<'pmu> PMU<'pmu> {
                 dpdctrl: &pmu.dpdctrl,
                 pcon   : &pmu.pcon,
             },
+            low_power_clock: LowPowerClock::new(),
         }
     }
 }

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -7,7 +7,6 @@ use cortex_m::{
     asm,
     interrupt,
 };
-use cortex_m::peripheral::SCB;
 use lpc82x;
 
 use clock;
@@ -31,7 +30,7 @@ impl<'pmu> PMU<'pmu> {
     ///
     /// The microcontroller will wake up from sleep mode, if an NVIC-enabled
     /// interrupt occurs. See user manual, section 6.7.4.3.
-    pub fn enter_sleep_mode(&mut self, scb: &SCB) {
+    pub fn enter_sleep_mode(&mut self, scb: &lpc82x::SCB) {
         interrupt::free(|_| {
             // Default power mode indicates active or sleep mode.
             self.0.pcon.modify(|_, w|

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -8,6 +8,10 @@ use cortex_m::{
     interrupt,
 };
 use lpc82x;
+use lpc82x::pmu::{
+    DPDCTRL,
+    PCON,
+};
 
 use clock;
 use clock::state::ClockState;
@@ -19,13 +23,30 @@ use clock::state::ClockState;
 /// [`lpc82x::PMU`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::PMU`]: ../../lpc82x/struct.PMU.html
-pub struct PMU<'pmu>(&'pmu lpc82x::PMU);
+pub struct PMU<'pmu> {
+    /// Main PMU API
+    pub api: Api<'pmu>,
+}
 
 impl<'pmu> PMU<'pmu> {
     pub(crate) fn new(pmu: &'pmu lpc82x::PMU) -> Self {
-        PMU(pmu)
+        PMU {
+            api: Api {
+                dpdctrl: &pmu.dpdctrl,
+                pcon   : &pmu.pcon,
+            },
+        }
     }
+}
 
+
+/// Main API of the PMU peripheral
+pub struct Api<'pmu> {
+    dpdctrl: &'pmu DPDCTRL,
+    pcon   : &'pmu PCON,
+}
+
+impl<'pmu> Api<'pmu> {
     /// Enter sleep mode
     ///
     /// The microcontroller will wake up from sleep mode, if an NVIC-enabled
@@ -33,7 +54,7 @@ impl<'pmu> PMU<'pmu> {
     pub fn enter_sleep_mode(&mut self, scb: &lpc82x::SCB) {
         interrupt::free(|_| {
             // Default power mode indicates active or sleep mode.
-            self.0.pcon.modify(|_, w|
+            self.pcon.modify(|_, w|
                 w.pm().default()
             );
             // The SLEEPDEEP bit must not be set for entering regular sleep
@@ -76,8 +97,8 @@ impl LowPowerClock<clock::state::Disabled> {
     /// instance that implements [`clock::Enabled`].
     ///
     /// [`clock::Enabled`]: ../clock/trait.Enabled.html
-    pub fn enable(self, pmu: &mut PMU) -> LowPowerClock<clock::state::Enabled> {
-        pmu.0.dpdctrl.modify(|_, w|
+    pub fn enable(self, pmu: &mut Api) -> LowPowerClock<clock::state::Enabled> {
+        pmu.dpdctrl.modify(|_, w|
             w.lposcen().enabled()
         );
 
@@ -92,10 +113,10 @@ impl LowPowerClock<clock::state::Enabled> {
     ///
     /// This method consumes an enabled instance of `LowPowerClock` and returns
     /// an instance that is disabled.
-    pub fn disable(self, pmu: &mut PMU)
+    pub fn disable(self, pmu: &mut Api)
         -> LowPowerClock<clock::state::Disabled>
     {
-        pmu.0.dpdctrl.modify(|_, w|
+        pmu.dpdctrl.modify(|_, w|
             w.lposcen().disabled()
         );
 

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -20,11 +20,11 @@ use clock::state::ClockState;
 /// [`lpc82x::PMU`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::PMU`]: ../../lpc82x/struct.PMU.html
-pub struct Pmu<'pmu>(&'pmu lpc82x::PMU);
+pub struct PMU<'pmu>(&'pmu lpc82x::PMU);
 
-impl<'pmu> Pmu<'pmu> {
+impl<'pmu> PMU<'pmu> {
     pub(crate) fn new(pmu: &'pmu lpc82x::PMU) -> Self {
-        Pmu(pmu)
+        PMU(pmu)
     }
 
     /// Enter sleep mode
@@ -77,7 +77,7 @@ impl LowPowerClock<clock::state::Disabled> {
     /// instance that implements [`clock::Enabled`].
     ///
     /// [`clock::Enabled`]: ../clock/trait.Enabled.html
-    pub fn enable(self, pmu: &mut Pmu) -> LowPowerClock<clock::state::Enabled> {
+    pub fn enable(self, pmu: &mut PMU) -> LowPowerClock<clock::state::Enabled> {
         pmu.0.dpdctrl.modify(|_, w|
             w.lposcen().enabled()
         );
@@ -93,7 +93,7 @@ impl LowPowerClock<clock::state::Enabled> {
     ///
     /// This method consumes an enabled instance of `LowPowerClock` and returns
     /// an instance that is disabled.
-    pub fn disable(self, pmu: &mut Pmu)
+    pub fn disable(self, pmu: &mut PMU)
         -> LowPowerClock<clock::state::Disabled>
     {
         pmu.0.dpdctrl.modify(|_, w|

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -9,7 +9,7 @@ use embedded_hal::prelude::*;
 use lpc82x;
 use nb;
 
-use Pmu;
+use PMU;
 use clock::{
     self,
     Ticks,
@@ -100,7 +100,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu, 'wkt> {
     nvic: &'r lpc82x::NVIC,
-    pmu : &'pmu mut Pmu<'pmu>,
+    pmu : &'pmu mut PMU<'pmu>,
     scb : &'r lpc82x::SCB,
     wkt : &'wkt mut WKT<'wkt>,
 }
@@ -109,7 +109,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
     /// Prepare regular sleep mode
     pub fn prepare(
         nvic: &'r lpc82x::NVIC,
-        pmu : &'pmu mut Pmu<'pmu>,
+        pmu : &'pmu mut PMU<'pmu>,
         scb : &'r lpc82x::SCB,
         wkt : &'wkt mut WKT<'wkt>,
     )

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -6,10 +6,7 @@
 
 use cortex_m::asm;
 use embedded_hal::prelude::*;
-use lpc82x::{
-    NVIC,
-    SCB,
-};
+use lpc82x;
 use nb;
 
 use Pmu;
@@ -102,18 +99,18 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [handle the WKT interrupt]: ../wkt/struct.WKT.html#method.handle_interrupt
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu, 'wkt> {
-    nvic: &'r NVIC,
+    nvic: &'r lpc82x::NVIC,
     pmu : &'pmu mut Pmu<'pmu>,
-    scb : &'r SCB,
+    scb : &'r lpc82x::SCB,
     wkt : &'wkt mut WKT<'wkt>,
 }
 
 impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
     /// Prepare regular sleep mode
     pub fn prepare(
-        nvic: &'r NVIC,
+        nvic: &'r lpc82x::NVIC,
         pmu : &'pmu mut Pmu<'pmu>,
-        scb : &'r SCB,
+        scb : &'r lpc82x::SCB,
         wkt : &'wkt mut WKT<'wkt>,
     )
         -> Self

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -19,7 +19,7 @@ use clock::{
 };
 use wkt::{
     self,
-    Wkt,
+    WKT,
 };
 
 
@@ -48,15 +48,15 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 /// only suitable for simple examples, or very short wait times.
 ///
 /// [`Sleep`]: trait.Sleep.html
-/// [WKT]: ../wkt/struct.Wkt.html
+/// [WKT]: ../wkt/struct.WKT.html
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Busy<'wkt> {
-    wkt: &'wkt mut Wkt<'wkt>,
+    wkt: &'wkt mut WKT<'wkt>,
 }
 
 impl<'wkt> Busy<'wkt> {
     /// Prepare busy sleep mode
-    pub fn prepare(wkt: &'wkt mut Wkt<'wkt>) -> Self {
+    pub fn prepare(wkt: &'wkt mut WKT<'wkt>) -> Self {
         Busy {
             wkt: wkt,
         }
@@ -98,14 +98,14 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// details.
 ///
 /// [`Sleep`]: trait.Sleep.html
-/// [WKT]: ../wkt/struct.Wkt.html
-/// [handle the WKT interrupt]: ../wkt/struct.Wkt.html#method.handle_interrupt
+/// [WKT]: ../wkt/struct.WKT.html
+/// [handle the WKT interrupt]: ../wkt/struct.WKT.html#method.handle_interrupt
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu, 'wkt> {
     nvic: &'r NVIC,
     pmu : &'pmu mut Pmu<'pmu>,
     scb : &'r SCB,
-    wkt : &'wkt mut Wkt<'wkt>,
+    wkt : &'wkt mut WKT<'wkt>,
 }
 
 impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
@@ -114,7 +114,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
         nvic: &'r NVIC,
         pmu : &'pmu mut Pmu<'pmu>,
         scb : &'r SCB,
-        wkt : &'wkt mut Wkt<'wkt>,
+        wkt : &'wkt mut WKT<'wkt>,
     )
         -> Self
     {

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -9,7 +9,7 @@ use embedded_hal::prelude::*;
 use lpc82x;
 use nb;
 
-use PMU;
+use pmu;
 use clock::{
     self,
     Ticks,
@@ -100,7 +100,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu, 'wkt> {
     nvic: &'r lpc82x::NVIC,
-    pmu : &'pmu mut PMU<'pmu>,
+    pmu : &'pmu mut pmu::Api<'pmu>,
     scb : &'r lpc82x::SCB,
     wkt : &'wkt mut WKT<'wkt>,
 }
@@ -109,7 +109,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
     /// Prepare regular sleep mode
     pub fn prepare(
         nvic: &'r lpc82x::NVIC,
-        pmu : &'pmu mut PMU<'pmu>,
+        pmu : &'pmu mut pmu::Api<'pmu>,
         scb : &'r lpc82x::SCB,
         wkt : &'wkt mut WKT<'wkt>,
     )

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -8,7 +8,7 @@ use lpc82x::swm::pinenable0;
 
 use ::{
     Pin,
-    Syscon,
+    SYSCON,
 };
 use init_state::{
     self,
@@ -36,7 +36,7 @@ impl<'swm> Swm<'swm, init_state::Unknown> {
     }
 
     /// Initialize the switch matrix
-    pub fn init(mut self, syscon: &mut Syscon)
+    pub fn init(mut self, syscon: &mut SYSCON)
         -> Swm<'swm, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.swm);

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -7,8 +7,8 @@ use lpc82x;
 use lpc82x::swm::pinenable0;
 
 use ::{
+    syscon,
     Pin,
-    SYSCON,
 };
 use init_state::{
     self,
@@ -36,7 +36,7 @@ impl<'swm> SWM<'swm, init_state::Unknown> {
     }
 
     /// Initialize the switch matrix
-    pub fn init(mut self, syscon: &mut SYSCON)
+    pub fn init(mut self, syscon: &mut syscon::Api)
         -> SWM<'swm, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.swm);

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -22,14 +22,14 @@ use init_state::{
 /// [`lpc82x::SWM`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::SWM`]: ../../lpc82x/struct.SWM.html
-pub struct Swm<'swm, State: InitState = init_state::Initialized> {
+pub struct SWM<'swm, State: InitState = init_state::Initialized> {
     swm   : &'swm lpc82x::SWM,
     _state: State,
 }
 
-impl<'swm> Swm<'swm, init_state::Unknown> {
+impl<'swm> SWM<'swm, init_state::Unknown> {
     pub(crate) fn new(swm: &'swm lpc82x::SWM) -> Self {
-        Swm {
+        SWM {
             swm   : swm,
             _state: init_state::Unknown,
         }
@@ -37,18 +37,18 @@ impl<'swm> Swm<'swm, init_state::Unknown> {
 
     /// Initialize the switch matrix
     pub fn init(mut self, syscon: &mut SYSCON)
-        -> Swm<'swm, init_state::Initialized>
+        -> SWM<'swm, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.swm);
 
-        Swm {
+        SWM {
             swm   : self.swm,
             _state: init_state::Initialized,
         }
     }
 }
 
-impl<'swm> Swm<'swm> {
+impl<'swm> SWM<'swm> {
     /// Assigns a movable function to a pin
     ///
     /// # Limitations
@@ -83,13 +83,13 @@ impl<'swm> Swm<'swm> {
 /// HAL users should not need to implement this trait.
 pub trait PinExt {
     /// Disables the fixed function on the pin
-    fn disable_fixed_functions(swm: &mut Swm);
+    fn disable_fixed_functions(swm: &mut SWM);
 }
 
 macro_rules! impl_pin_ext {
     ($pin:ty $(, $fixed_function:ty)*) => {
         impl PinExt for $pin {
-            fn disable_fixed_functions(_swm: &mut Swm) {
+            fn disable_fixed_functions(_swm: &mut SWM) {
                 $(
                     _swm.disable_fixed_function::<$fixed_function>();
                 )*
@@ -143,10 +143,10 @@ macro_rules! impl_movable_function {
     ($movable_function:ident, $register:ident, $field:ident) => {
         /// Represents a movable function
         ///
-        /// Can be used with [`Swm::assign_pin`] to assign this movable function
+        /// Can be used with [`SWM::assign_pin`] to assign this movable function
         /// to a pin.
         ///
-        /// [`Swm::assign_pin`]: struct.Swm.html#method.assign_pin
+        /// [`SWM::assign_pin`]: struct.SWM.html#method.assign_pin
         #[allow(non_camel_case_types)]
         pub struct $movable_function;
 
@@ -227,11 +227,11 @@ macro_rules! impl_fixed_function {
     ($fixed_function:ident, $field:ident) => {
         /// Represents a fixed function
         ///
-        /// Can be used with [`Swm::enable_fixed_function`] and
-        /// [`Swm::disable_fixed_function`].
+        /// Can be used with [`SWM::enable_fixed_function`] and
+        /// [`SWM::disable_fixed_function`].
         ///
-        /// [`Swm::enable_fixed_function`]: struct.Swm.html#method.enable_fixed_function
-        /// [`Swm::disable_fixed_function`]: struct.Swm.html#method.disable_fixed_function
+        /// [`SWM::enable_fixed_function`]: struct.SWM.html#method.enable_fixed_function
+        /// [`SWM::disable_fixed_function`]: struct.SWM.html#method.disable_fixed_function
         #[allow(non_camel_case_types)]
         pub struct $fixed_function;
 

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -61,6 +61,11 @@ pub struct SYSCON<'syscon> {
 
     /// UART Fractional Baud Rate Generator
     pub uartfrg: UARTFRG,
+
+    /// The 750 kHz IRC-derived clock
+    ///
+    /// Can be used to run the self-wake-up timer (WKT).
+    pub irc_derived_clock: IrcDerivedClock<clock::state::Disabled>,
 }
 
 impl<'syscon> SYSCON<'syscon> {
@@ -85,6 +90,8 @@ impl<'syscon> SYSCON<'syscon> {
             sysosc : SYSOSC::new(),
             syspll : SYSPLL::new(),
             uartfrg: UARTFRG::new(),
+
+            irc_derived_clock: IrcDerivedClock::new(),
         }
     }
 }

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -31,6 +31,36 @@ use clock::state::ClockState;
 pub struct SYSCON<'syscon> {
     /// Main SYSCON API
     pub api: Api<'syscon>,
+
+    /// Brown-out detection
+    pub bod: BOD,
+
+    /// Flash memory
+    pub flash: FLASH,
+
+    /// IRC
+    pub irc: IRC,
+
+    /// IRC output
+    pub ircout: IRCOUT,
+
+    /// Micro Trace Buffer
+    pub mtb: MTB,
+
+    /// Random access memory
+    pub ram0_1: RAM0_1,
+
+    /// Read-only memory
+    pub rom: ROM,
+
+    /// System oscillator
+    pub sysosc: SYSOSC,
+
+    /// PLL
+    pub syspll: SYSPLL,
+
+    /// UART Fractional Baud Rate Generator
+    pub uartfrg: UARTFRG,
 }
 
 impl<'syscon> SYSCON<'syscon> {
@@ -44,6 +74,17 @@ impl<'syscon> SYSCON<'syscon> {
                 uartfrgdiv   : &syscon.uartfrgdiv,
                 uartfrgmult  : &syscon.uartfrgmult,
             },
+
+            bod    : BOD::new(),
+            flash  : FLASH::new(),
+            irc    : IRC::new(),
+            ircout : IRCOUT::new(),
+            mtb    : MTB::new(),
+            ram0_1 : RAM0_1::new(),
+            rom    : ROM::new(),
+            sysosc : SYSOSC::new(),
+            syspll : SYSPLL::new(),
+            uartfrg: UARTFRG::new(),
         }
     }
 }

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -22,11 +22,11 @@ use clock::state::ClockState;
 /// [`lpc82x::SYSCON`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::SYSCON`]: ../../lpc82x/struct.SYSCON.html
-pub struct Syscon<'syscon>(&'syscon lpc82x::SYSCON);
+pub struct SYSCON<'syscon>(&'syscon lpc82x::SYSCON);
 
-impl<'syscon> Syscon<'syscon> {
+impl<'syscon> SYSCON<'syscon> {
     pub(crate) fn new(syscon: &'syscon lpc82x::SYSCON) -> Self {
-        Syscon(syscon)
+        SYSCON(syscon)
     }
 
     /// Enable peripheral clock
@@ -98,9 +98,9 @@ impl<'syscon> Syscon<'syscon> {
 
 /// Brown-out detection
 ///
-/// Can be used to control brown-out detection using various [`Syscon`] methods.
+/// Can be used to control brown-out detection using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct BOD(PhantomData<*const ()>);
 
 impl BOD {
@@ -112,9 +112,9 @@ impl BOD {
 
 /// Flash memory
 ///
-/// Can be used to control the flash memory using various [`Syscon`] methods.
+/// Can be used to control the flash memory using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct FLASH(PhantomData<*const ()>);
 
 impl FLASH {
@@ -126,9 +126,9 @@ impl FLASH {
 
 /// IRC
 ///
-/// Can be used to control the IRC using various [`Syscon`] methods.
+/// Can be used to control the IRC using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct IRC(PhantomData<*const ()>);
 
 impl IRC {
@@ -140,9 +140,9 @@ impl IRC {
 
 /// IRC output
 ///
-/// Can be used to control IRC output using various [`Syscon`] methods.
+/// Can be used to control IRC output using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct IRCOUT(PhantomData<*const ()>);
 
 impl IRCOUT {
@@ -154,10 +154,10 @@ impl IRCOUT {
 
 /// Micro Trace Buffer
 ///
-/// Can be used to control the Micro Trace Buffer using various [`Syscon`]
+/// Can be used to control the Micro Trace Buffer using various [`SYSCON`]
 /// methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct MTB(PhantomData<*const ()>);
 
 impl MTB {
@@ -169,9 +169,9 @@ impl MTB {
 
 /// Random access memory
 ///
-/// Can be used to control the RAM using various [`Syscon`] methods.
+/// Can be used to control the RAM using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 #[allow(non_camel_case_types)]
 pub struct RAM0_1(PhantomData<*const ()>);
 
@@ -184,9 +184,9 @@ impl RAM0_1 {
 
 /// Read-only memory
 ///
-/// Can be used to control the ROM using various [`Syscon`] methods.
+/// Can be used to control the ROM using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct ROM(PhantomData<*const ()>);
 
 impl ROM {
@@ -198,10 +198,10 @@ impl ROM {
 
 /// System oscillator
 ///
-/// Can be used to control the system oscillator using various [`Syscon`]
+/// Can be used to control the system oscillator using various [`SYSCON`]
 /// methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct SYSOSC(PhantomData<*const ()>);
 
 impl SYSOSC {
@@ -213,9 +213,9 @@ impl SYSOSC {
 
 /// PLL
 ///
-/// Can be used to control the PLL using various [`Syscon`] methods.
+/// Can be used to control the PLL using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct SYSPLL(PhantomData<*const ()>);
 
 impl SYSPLL {
@@ -227,9 +227,9 @@ impl SYSPLL {
 
 /// UART Fractional Baud Rate Generator
 ///
-/// Can be used to control the UART FRG using various [`Syscon`] methods.
+/// Can be used to control the UART FRG using various [`SYSCON`] methods.
 ///
-/// [`Syscon`]: struct.Syscon.html
+/// [`SYSCON`]: struct.SYSCON.html
 pub struct UARTFRG(PhantomData<*const ()>);
 
 impl UARTFRG {
@@ -246,11 +246,11 @@ impl UARTFRG {
 /// implemented nor used outside of LPC82x HAL. Any incompatible changes to this
 /// trait won't be considered breaking changes.
 ///
-/// Please refer to [`Syscon::enable_clock`] and [`Syscon::disable_clock`] for
+/// Please refer to [`SYSCON::enable_clock`] and [`SYSCON::disable_clock`] for
 /// the public API that uses this trait.
 ///
-/// [`Syscon::enable_clock`]: struct.Syscon.html#method.enable_clock
-/// [`Syscon::disable_clock`]: struct.Syscon.html#method.disable_clock
+/// [`SYSCON::enable_clock`]: struct.SYSCON.html#method.enable_clock
+/// [`SYSCON::disable_clock`]: struct.SYSCON.html#method.disable_clock
 pub trait ClockControl {
     /// Internal method to enable a peripheral clock
     fn enable_clock<'w>(&mut self, w: &'w mut sysahbclkctrl::W)
@@ -312,11 +312,11 @@ impl_enable_clock!(&'a lpc82x::DMA      , dma     );
 /// implemented nor used outside of LPC82x HAL. Any incompatible changes to this
 /// trait won't be considered breaking changes.
 ///
-/// Please refer to [`Syscon::assert_reset`] and [`Syscon::clear_reset`] for the
+/// Please refer to [`SYSCON::assert_reset`] and [`SYSCON::clear_reset`] for the
 /// public API that uses this trait.
 ///
-/// [`Syscon::assert_reset`]: struct.Syscon.html#method.assert_reset
-/// [`Syscon::clear_reset`]: struct.Syscon.html#method.clear_reset
+/// [`SYSCON::assert_reset`]: struct.SYSCON.html#method.assert_reset
+/// [`SYSCON::clear_reset`]: struct.SYSCON.html#method.clear_reset
 pub trait ResetControl {
     /// Internal method to assert peripheral reset
     fn assert_reset<'w>(&mut self, w: &'w mut presetctrl::W)
@@ -366,11 +366,11 @@ impl_clear_reset!(&'a lpc82x::CMP      , acmp_rst_n   );
 /// implemented nor used outside of LPC82x HAL. Any incompatible changes to this
 /// trait won't be considered breaking changes.
 ///
-/// Please refer to [`Syscon::power_up`] and [`Syscon::power_down`] for the
+/// Please refer to [`SYSCON::power_up`] and [`SYSCON::power_down`] for the
 /// public API that uses this trait.
 ///
-/// [`Syscon::power_up`]: struct.Syscon.html#method.power_up
-/// [`Syscon::power_down`]: struct.Syscon.html#method.power_down
+/// [`SYSCON::power_up`]: struct.SYSCON.html#method.power_up
+/// [`SYSCON::power_down`]: struct.SYSCON.html#method.power_down
 pub trait AnalogBlock {
     /// Internal method to power up an analog block
     fn power_up<'w>(&mut self, w: &'w mut pdruncfg::W) -> &'w mut pdruncfg::W;
@@ -410,23 +410,23 @@ impl_analog_block!(&'a lpc82x::CMP , acmp      );
 
 /// UART clock divider value
 ///
-/// See [`Syscon::set_uart_clock`].
+/// See [`SYSCON::set_uart_clock`].
 ///
-/// [`Syscon::set_uart_clock`]: struct.Syscon.html#method.set_uart_clock
+/// [`SYSCON::set_uart_clock`]: struct.SYSCON.html#method.set_uart_clock
 pub struct UartClkDiv(pub u8);
 
 /// UART fractional generator multiplier value
 ///
-/// See [`Syscon::set_uart_clock`].
+/// See [`SYSCON::set_uart_clock`].
 ///
-/// [`Syscon::set_uart_clock`]: struct.Syscon.html#method.set_uart_clock
+/// [`SYSCON::set_uart_clock`]: struct.SYSCON.html#method.set_uart_clock
 pub struct UartFrgMult(pub u8);
 
 /// UART fractional generator divider value
 ///
-/// See [`Syscon::set_uart_clock`].
+/// See [`SYSCON::set_uart_clock`].
 ///
-/// [`Syscon::set_uart_clock`]: struct.Syscon.html#method.set_uart_clock
+/// [`SYSCON::set_uart_clock`]: struct.SYSCON.html#method.set_uart_clock
 pub struct UartFrgDiv(pub u8);
 
 
@@ -454,7 +454,7 @@ impl IrcDerivedClock<clock::state::Disabled> {
     /// the IRC-derived clock again.
     ///
     /// [`clock::Enabled`]: ../clock/trait.Enabled.html
-    pub fn enable(self, syscon: &mut Syscon, mut irc: IRC, mut ircout: IRCOUT)
+    pub fn enable(self, syscon: &mut SYSCON, mut irc: IRC, mut ircout: IRCOUT)
         -> IrcDerivedClock<clock::state::Enabled>
     {
         syscon.power_up(&mut irc);

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -80,16 +80,16 @@ impl<'syscon> SYSCON<'syscon> {
                 uartfrgmult  : &syscon.uartfrgmult,
             },
 
-            bod    : BOD::new(),
-            flash  : FLASH::new(),
-            irc    : IRC::new(),
-            ircout : IRCOUT::new(),
-            mtb    : MTB::new(),
-            ram0_1 : RAM0_1::new(),
-            rom    : ROM::new(),
-            sysosc : SYSOSC::new(),
-            syspll : SYSPLL::new(),
-            uartfrg: UARTFRG::new(),
+            bod    : BOD(PhantomData),
+            flash  : FLASH(PhantomData),
+            irc    : IRC(PhantomData),
+            ircout : IRCOUT(PhantomData),
+            mtb    : MTB(PhantomData),
+            ram0_1 : RAM0_1(PhantomData),
+            rom    : ROM(PhantomData),
+            sysosc : SYSOSC(PhantomData),
+            syspll : SYSPLL(PhantomData),
+            uartfrg: UARTFRG(PhantomData),
 
             irc_derived_clock: IrcDerivedClock::new(),
         }
@@ -182,26 +182,12 @@ impl<'r> Api<'r> {
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct BOD(PhantomData<*const ()>);
 
-impl BOD {
-    pub(crate) fn new() -> Self {
-        BOD(PhantomData)
-    }
-}
-
-
 /// Flash memory
 ///
 /// Can be used to control the flash memory using various [`SYSCON`] methods.
 ///
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct FLASH(PhantomData<*const ()>);
-
-impl FLASH {
-    pub(crate) fn new() -> Self {
-        FLASH(PhantomData)
-    }
-}
-
 
 /// IRC
 ///
@@ -210,26 +196,12 @@ impl FLASH {
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct IRC(PhantomData<*const ()>);
 
-impl IRC {
-    pub(crate) fn new() -> Self {
-        IRC(PhantomData)
-    }
-}
-
-
 /// IRC output
 ///
 /// Can be used to control IRC output using various [`SYSCON`] methods.
 ///
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct IRCOUT(PhantomData<*const ()>);
-
-impl IRCOUT {
-    pub(crate) fn new() -> Self {
-        IRCOUT(PhantomData)
-    }
-}
-
 
 /// Micro Trace Buffer
 ///
@@ -239,13 +211,6 @@ impl IRCOUT {
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct MTB(PhantomData<*const ()>);
 
-impl MTB {
-    pub(crate) fn new() -> Self {
-        MTB(PhantomData)
-    }
-}
-
-
 /// Random access memory
 ///
 /// Can be used to control the RAM using various [`SYSCON`] methods.
@@ -254,26 +219,12 @@ impl MTB {
 #[allow(non_camel_case_types)]
 pub struct RAM0_1(PhantomData<*const ()>);
 
-impl RAM0_1 {
-    pub(crate) fn new() -> Self {
-        RAM0_1(PhantomData)
-    }
-}
-
-
 /// Read-only memory
 ///
 /// Can be used to control the ROM using various [`SYSCON`] methods.
 ///
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct ROM(PhantomData<*const ()>);
-
-impl ROM {
-    pub(crate) fn new() -> Self {
-        ROM(PhantomData)
-    }
-}
-
 
 /// System oscillator
 ///
@@ -283,13 +234,6 @@ impl ROM {
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct SYSOSC(PhantomData<*const ()>);
 
-impl SYSOSC {
-    pub(crate) fn new() -> Self {
-        SYSOSC(PhantomData)
-    }
-}
-
-
 /// PLL
 ///
 /// Can be used to control the PLL using various [`SYSCON`] methods.
@@ -297,26 +241,12 @@ impl SYSOSC {
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct SYSPLL(PhantomData<*const ()>);
 
-impl SYSPLL {
-    pub(crate) fn new() -> Self {
-        SYSPLL(PhantomData)
-    }
-}
-
-
 /// UART Fractional Baud Rate Generator
 ///
 /// Can be used to control the UART FRG using various [`SYSCON`] methods.
 ///
 /// [`SYSCON`]: struct.SYSCON.html
 pub struct UARTFRG(PhantomData<*const ()>);
-
-impl UARTFRG {
-    pub(crate) fn new() -> Self {
-        UARTFRG(PhantomData)
-    }
-}
-
 
 
 /// Implemented for peripherals that have a clock that can be enabled

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -24,7 +24,7 @@ use swm::{
 };
 use syscon::{
     self,
-    Syscon,
+    SYSCON,
     UartClkDiv,
     UartFrgDiv,
     UartFrgMult,
@@ -93,7 +93,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     /// [`BaudRate`]: struct.BaudRate.html
     pub fn init<Rx: Pin, Tx: Pin>(mut self,
         baud_rate: &BaudRate,
-        syscon   : &mut Syscon,
+        syscon   : &mut SYSCON,
         swm      : &mut Swm,
     ) -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !> {
         syscon.enable_clock(&mut self.usart);

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -24,7 +24,6 @@ use swm::{
 };
 use syscon::{
     self,
-    SYSCON,
     UartClkDiv,
     UartFrgDiv,
     UartFrgMult,
@@ -93,7 +92,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     /// [`BaudRate`]: struct.BaudRate.html
     pub fn init<Rx: Pin, Tx: Pin>(mut self,
         baud_rate: &BaudRate,
-        syscon   : &mut SYSCON,
+        syscon   : &mut syscon::Api,
         swm      : &mut SWM,
     ) -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !> {
         syscon.enable_clock(&mut self.usart);

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -20,7 +20,7 @@ use init_state::{
 };
 use swm::{
     self,
-    Swm,
+    SWM,
 };
 use syscon::{
     self,
@@ -94,7 +94,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     pub fn init<Rx: Pin, Tx: Pin>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut SYSCON,
-        swm      : &mut Swm,
+        swm      : &mut SWM,
     ) -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !> {
         syscon.enable_clock(&mut self.usart);
         syscon.clear_reset(&mut self.usart);

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -54,14 +54,14 @@ pub trait Write<Word> {
 
 /// Interface to the USART peripherals
 ///
-/// Each instance of `Usart` expects to have full ownership of one USART
+/// Each instance of `USART` expects to have full ownership of one USART
 /// peripheral. Don't use [`lpc82x::USART0`], [`lpc82x::USART1`], or
 /// [`lpc82x::USART2`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::USART0`]: ../../lpc82x/struct.USART0.html
 /// [`lpc82x::USART1`]: ../../lpc82x/struct.USART1.html
 /// [`lpc82x::USART2`]: ../../lpc82x/struct.USART2.html
-pub struct Usart<
+pub struct USART<
     'usart,
     UsartX: 'usart,
     State : InitState = init_state::Initialized,
@@ -70,13 +70,13 @@ pub struct Usart<
     _state: State,
 }
 
-impl<'usart, UsartX> Usart<'usart, UsartX, init_state::Unknown>
+impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     where
         UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     pub(crate) fn new(usart: &'usart UsartX) -> Self {
-        Usart {
+        USART {
             usart : usart,
             _state: init_state::Unknown,
         }
@@ -95,7 +95,7 @@ impl<'usart, UsartX> Usart<'usart, UsartX, init_state::Unknown>
         baud_rate: &BaudRate,
         syscon   : &mut Syscon,
         swm      : &mut Swm,
-    ) -> nb::Result<Usart<'usart, UsartX, init_state::Initialized>, !> {
+    ) -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !> {
         syscon.enable_clock(&mut self.usart);
         syscon.clear_reset(&mut self.usart);
 
@@ -161,14 +161,14 @@ impl<'usart, UsartX> Usart<'usart, UsartX, init_state::Unknown>
                 .autobaud().disabled()
         );
 
-        Ok(Usart {
+        Ok(USART {
             usart : self.usart,
             _state: init_state::Initialized,
         })
     }
 }
 
-impl<'usart, UsartX> Usart<'usart, UsartX>
+impl<'usart, UsartX> USART<'usart, UsartX>
     where
         UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
@@ -211,7 +211,7 @@ impl<'usart, UsartX> Usart<'usart, UsartX>
     }
 }
 
-impl<'usart, UsartX> Read<u8> for Usart<'usart, UsartX>
+impl<'usart, UsartX> Read<u8> for USART<'usart, UsartX>
     where
         UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
@@ -256,7 +256,7 @@ impl<'usart, UsartX> Read<u8> for Usart<'usart, UsartX>
     }
 }
 
-impl<'usart, UsartX> Write<u8> for Usart<'usart, UsartX>
+impl<'usart, UsartX> Write<u8> for USART<'usart, UsartX>
     where
         UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
@@ -284,7 +284,7 @@ impl<'usart, UsartX> Write<u8> for Usart<'usart, UsartX>
     }
 }
 
-impl<'usart, UsartX> blocking::Write<u8> for Usart<'usart, UsartX>
+impl<'usart, UsartX> blocking::Write<u8> for USART<'usart, UsartX>
     where
         UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
@@ -348,7 +348,7 @@ impl Peripheral for lpc82x::USART2 {
 
 /// Baud rate for a UART unit
 ///
-/// Can be passed to [`Usart::init`] to configure the baud rate for the USART
+/// Can be passed to [`USART::init`] to configure the baud rate for the USART
 /// peripheral.
 ///
 /// # Limitations
@@ -361,7 +361,7 @@ impl Peripheral for lpc82x::USART2 {
 /// that all the `BaudRate`s passed to them have identical values for `clk_div`,
 /// `frg_mult`, and `frg_div`.
 ///
-/// [`Usart::init`]: struct.Usart.html#method.init
+/// [`USART::init`]: struct.USART.html#method.init
 /// [`clk_div`]: #structfield.clk_div
 /// [`frg_mult`]: #structfield.frg_mult
 /// [`frg_div`]: #structfield.frg_div

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -13,8 +13,6 @@ use embedded_hal;
 use lpc82x::{
     self,
     Interrupt,
-    NVIC,
-    WKT,
 };
 use lpc82x::wkt::ctrl;
 use nb;
@@ -103,7 +101,7 @@ impl<'wkt> Wkt<'wkt> {
     /// See [`handle_interrupt`] for details.
     ///
     /// [`handle_interrupt`]: #method.handle_interrupt
-    pub fn enable_interrupt(&mut self, nvic: &NVIC) {
+    pub fn enable_interrupt(&mut self, nvic: &lpc82x::NVIC) {
         nvic.enable(Interrupt::WKT);
     }
 
@@ -150,7 +148,7 @@ impl<'wkt> Wkt<'wkt> {
 
             // Reset the alarm flag. Otherwise the interrupt will be triggered
             // over and over.
-            WKT.borrow(cs).ctrl.modify(|_, w| w.alarmflag().set_bit());
+            lpc82x::WKT.borrow(cs).ctrl.modify(|_, w| w.alarmflag().set_bit());
         });
     }
 }

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -18,8 +18,8 @@ use lpc82x::wkt::ctrl;
 use nb;
 
 use syscon::{
+    self,
     IrcDerivedClock,
-    SYSCON,
 };
 use clock::state::ClockState;
 use init_state::{
@@ -63,7 +63,7 @@ impl<'wkt> WKT<'wkt, init_state::Unknown> {
     }
 
     /// Initialize the self-wake-up timer
-    pub fn init(mut self, syscon: &mut SYSCON)
+    pub fn init(mut self, syscon: &mut syscon::Api)
         -> WKT<'wkt, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.wkt);

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -49,14 +49,14 @@ static HAS_WOKEN: Mutex<RefCell<bool>> = Mutex::new(RefCell::new(false));
 /// [`Timer`]: ../../embedded_hal/trait.Timer.html
 /// [`Timer::set_timeout`]: ../../embedded_hal/trait.Timer.html#tymethod.set_timeout
 /// [`Timer::wait`]: ../../embedded_hal/trait.Timer.html#tymethod.wait
-pub struct Wkt<'wkt, State: InitState = init_state::Initialized> {
+pub struct WKT<'wkt, State: InitState = init_state::Initialized> {
     wkt   : &'wkt lpc82x::WKT,
     _state: State,
 }
 
-impl<'wkt> Wkt<'wkt, init_state::Unknown> {
+impl<'wkt> WKT<'wkt, init_state::Unknown> {
     pub(crate) fn new(wkt: &'wkt lpc82x::WKT) -> Self {
-        Wkt {
+        WKT {
             wkt   : wkt,
             _state: init_state::Unknown,
         }
@@ -64,19 +64,19 @@ impl<'wkt> Wkt<'wkt, init_state::Unknown> {
 
     /// Initialize the self-wake-up timer
     pub fn init(mut self, syscon: &mut Syscon)
-        -> Wkt<'wkt, init_state::Initialized>
+        -> WKT<'wkt, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.wkt);
         syscon.clear_reset(&mut self.wkt);
 
-        Wkt {
+        WKT {
             wkt   : self.wkt,
             _state: init_state::Initialized,
         }
     }
 }
 
-impl<'wkt> Wkt<'wkt> {
+impl<'wkt> WKT<'wkt> {
     /// Select the clock that runs the self-wake-up timer
     ///
     /// Clocks that can run the self-wake-up timer implement [`wkt::Clock`].
@@ -127,12 +127,12 @@ impl<'wkt> Wkt<'wkt> {
     /// extern crate lpc82x;
     /// extern crate lpc82x_hal;
     ///
-    /// use lpc82x_hal::Wkt;
+    /// use lpc82x_hal::WKT;
     ///
     /// interrupt!(WKT, handle_wkt);
     ///
     /// fn handle_wkt() {
-    ///     Wkt::handle_interrupt();
+    ///     WKT::handle_interrupt();
     /// }
     /// #
     /// # fn main() {}
@@ -153,7 +153,7 @@ impl<'wkt> Wkt<'wkt> {
     }
 }
 
-impl<'wkt> embedded_hal::Timer for Wkt<'wkt> {
+impl<'wkt> embedded_hal::Timer for WKT<'wkt> {
     type Time = u32;
 
     fn get_timeout(&self) -> Self::Time {

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -19,7 +19,7 @@ use nb;
 
 use syscon::{
     IrcDerivedClock,
-    Syscon,
+    SYSCON,
 };
 use clock::state::ClockState;
 use init_state::{
@@ -63,7 +63,7 @@ impl<'wkt> WKT<'wkt, init_state::Unknown> {
     }
 
     /// Initialize the self-wake-up timer
-    pub fn init(mut self, syscon: &mut Syscon)
+    pub fn init(mut self, syscon: &mut SYSCON)
         -> WKT<'wkt, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.wkt);


### PR DESCRIPTION
Simplifies the API by removing `System`, `Clocks`, and `Resources`, only leaving `Peripherals`. Types that were previously accessible from `Clocks` and `Resources` have been moved into their respective peripheral modules. `syscon` and `pmu` have been reorganized to accomodate that.

Also renames all peripheral types to more closely follow the language used in the user manual. See #18 for a discussion of the issue.