### PR TITLE
Improve baud rate API

### DIFF
--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -423,28 +423,6 @@ impl_analog_block!(SYSPLL          , syspll_pd );
 impl_analog_block!(&'a lpc82x::CMP , acmp      );
 
 
-/// UART clock divider value
-///
-/// See [`SYSCON::set_uart_clock`].
-///
-/// [`SYSCON::set_uart_clock`]: struct.SYSCON.html#method.set_uart_clock
-pub struct UartClkDiv(pub u8);
-
-/// UART fractional generator multiplier value
-///
-/// See [`SYSCON::set_uart_clock`].
-///
-/// [`SYSCON::set_uart_clock`]: struct.SYSCON.html#method.set_uart_clock
-pub struct UartFrgMult(pub u8);
-
-/// UART fractional generator divider value
-///
-/// See [`SYSCON::set_uart_clock`].
-///
-/// [`SYSCON::set_uart_clock`]: struct.SYSCON.html#method.set_uart_clock
-pub struct UartFrgDiv(pub u8);
-
-
 /// The 750 kHz IRC-derived clock that can run the WKT
 ///
 /// See user manual, section 18.5.1.

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -60,7 +60,7 @@ pub struct SYSCON<'syscon> {
     pub syspll: SYSPLL,
 
     /// UART Fractional Baud Rate Generator
-    pub uartfrg: UARTFRG,
+    pub uartfrg: UARTFRG<'syscon>,
 
     /// The 750 kHz IRC-derived clock
     ///
@@ -75,9 +75,6 @@ impl<'syscon> SYSCON<'syscon> {
                 pdruncfg     : &syscon.pdruncfg,
                 presetctrl   : &syscon.presetctrl,
                 sysahbclkctrl: &syscon.sysahbclkctrl,
-                uartclkdiv   : &syscon.uartclkdiv,
-                uartfrgdiv   : &syscon.uartfrgdiv,
-                uartfrgmult  : &syscon.uartfrgmult,
             },
 
             bod    : BOD(PhantomData),
@@ -89,7 +86,12 @@ impl<'syscon> SYSCON<'syscon> {
             rom    : ROM(PhantomData),
             sysosc : SYSOSC(PhantomData),
             syspll : SYSPLL(PhantomData),
-            uartfrg: UARTFRG(PhantomData),
+            uartfrg: UARTFRG {
+                uartclkdiv : &syscon.uartclkdiv,
+                uartfrgdiv : &syscon.uartfrgdiv,
+                uartfrgmult: &syscon.uartfrgmult,
+
+            },
 
             irc_derived_clock: IrcDerivedClock::new(),
         }
@@ -102,9 +104,6 @@ pub struct Api<'syscon> {
     pdruncfg     : &'syscon PDRUNCFG,
     presetctrl   : &'syscon PRESETCTRL,
     sysahbclkctrl: &'syscon SYSAHBCLKCTRL,
-    uartclkdiv   : &'syscon UARTCLKDIV,
-    uartfrgdiv   : &'syscon UARTFRGDIV,
-    uartfrgmult  : &'syscon UARTFRGMULT,
 }
 
 impl<'r> Api<'r> {
@@ -147,30 +146,6 @@ impl<'r> Api<'r> {
     /// Remove power from an analog block
     pub fn power_down<P: AnalogBlock>(&mut self, peripheral: &mut P) {
         self.pdruncfg.modify(|_, w| peripheral.power_down(w));
-    }
-
-    /// Sets the clock for all USART peripherals (U_PCLK)
-    ///
-    /// HAL users usually won't have to call this method directly, as the
-    /// [`Usart`] API will handle this.
-    ///
-    /// # Limitations
-    ///
-    /// This method can be used to overwrite the settings for USARTs that are
-    /// currently in use. Please make sure not to do that.
-    ///
-    /// [`Usart`]: ../usart/struct.Usart.html
-    pub fn set_uart_clock(&mut self,
-        uart_clk_div : &UartClkDiv,
-        uart_frg_mult: &UartFrgMult,
-        uart_frg_div : &UartFrgDiv,
-    ) {
-        unsafe {
-            self.uartclkdiv.write(|w| w.div().bits(uart_clk_div.0));
-
-            self.uartfrgmult.write(|w| w.mult().bits(uart_frg_mult.0));
-            self.uartfrgdiv.write(|w| w.div().bits(uart_frg_div.0));
-        }
     }
 }
 
@@ -243,10 +218,41 @@ pub struct SYSPLL(PhantomData<*const ()>);
 
 /// UART Fractional Baud Rate Generator
 ///
-/// Can be used to control the UART FRG using various [`SYSCON`] methods.
-///
-/// [`SYSCON`]: struct.SYSCON.html
-pub struct UARTFRG(PhantomData<*const ()>);
+/// Controls the clock for all USART peripherals (U_PCLK).
+pub struct UARTFRG<'syscon> {
+    uartclkdiv : &'syscon UARTCLKDIV,
+    uartfrgdiv : &'syscon UARTFRGDIV,
+    uartfrgmult: &'syscon UARTFRGMULT,
+}
+
+impl<'syscon> UARTFRG<'syscon> {
+    /// Set UART clock divider value (UARTCLKDIV)
+    ///
+    /// See user manual, section 5.6.15.
+    pub fn set_clkdiv(&mut self, value: u8) {
+        self.uartclkdiv.write(|w|
+            unsafe { w.div().bits(value) }
+        );
+    }
+
+    /// Set UART fractional generator multiplier value (UARTFRGMULT)
+    ///
+    /// See user manual, section 5.6.20.
+    pub fn set_frgmult(&mut self, value: u8) {
+        self.uartfrgmult.write(|w|
+            unsafe { w.mult().bits(value) }
+        );
+    }
+
+    /// Set UART fractional generator divider value (UARTFRGDIV)
+    ///
+    /// See user manual, section 5.6.19.
+    pub fn set_frgdiv(&mut self, value: u8) {
+        self.uartfrgdiv.write(|w|
+            unsafe { w.div().bits(value) }
+        );
+    }
+}
 
 
 /// Implemented for peripherals that have a clock that can be enabled
@@ -356,7 +362,7 @@ macro_rules! impl_clear_reset {
 
 impl_clear_reset!(&'a lpc82x::SPI0     , spi0_rst_n   );
 impl_clear_reset!(&'a lpc82x::SPI1     , spi1_rst_n   );
-impl_clear_reset!(UARTFRG              , uartfrg_rst_n);
+impl_clear_reset!(UARTFRG<'a>          , uartfrg_rst_n);
 impl_clear_reset!(&'a lpc82x::USART0   , uart0_rst_n  );
 impl_clear_reset!(&'a lpc82x::USART1   , uart1_rst_n  );
 impl_clear_reset!(&'a lpc82x::USART2   , uart2_rst_n  );

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -338,26 +338,12 @@ impl Peripheral for lpc82x::USART2 {
 }
 
 
-/// Baud rate for a UART unit
+/// Represents a UART baud rate
 ///
-/// Can be passed to [`USART::init`] to configure the baud rate for the USART
+/// Can be passed to [`USART::init`] to configure the baud rate for a USART
 /// peripheral.
 ///
-/// # Limitations
-///
-/// The fields [`clk_div`], [`frg_mult`], and [`frg_div`] represent global
-/// configuration values that are shared between all USART peripherals. Only
-/// [`brg_val`] can be set independently for each USART.
-///
-/// When running multiple USARTs, it is the user's responsibility to make sure
-/// that all the `BaudRate`s passed to them have identical values for `clk_div`,
-/// `frg_mult`, and `frg_div`.
-///
 /// [`USART::init`]: struct.USART.html#method.init
-/// [`clk_div`]: #structfield.clk_div
-/// [`frg_mult`]: #structfield.frg_mult
-/// [`frg_div`]: #structfield.frg_div
-/// [`brg_val`]: #structfield.brg_val
 pub struct BaudRate<'frg> {
     _uartfrg: &'frg UARTFRG<'frg>,
 
@@ -368,7 +354,23 @@ pub struct BaudRate<'frg> {
 }
 
 impl<'frg> BaudRate<'frg> {
-    /// Create a `BaudRate` instance by providing the register values
+    /// Create a `BaudRate` instance
+    ///
+    /// Creates a `BaudRate` instance from two components: A reference to the
+    /// [`UARTFRG`] and the BRGVAL.
+    ///
+    /// The [`UARTFRG`] controls U_PCLK, the UART clock that is shared by all
+    /// USART peripherals. Please configure it before attempting to create a
+    /// `BaudRate`. By keeping a reference to it, `BaudRate` ensures that U_PCLK
+    /// cannot be changes as long as the `BaudRate` instance exists.
+    ///
+    /// BRGVAL is an additional divider value that divides the shared baud rate
+    /// to allow individual USART peripherals to use different baud rates. A
+    /// value of `0` means that U_PCLK is used directly, `1` means that U_PCLK
+    /// is divided by 2 before using it, `2` means it's divided by 3, and so
+    /// forth.
+    ///
+    /// [`UARTFRG`]: ../syscon/struct.UARTFRG.html
     pub fn new(uartfrg : &'frg UARTFRG<'frg>, brg_val : u16) -> Self {
         Self {
             _uartfrg: uartfrg,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -375,44 +375,6 @@ impl<'frg> BaudRate<'frg> {
             brg_val : brg_val,
         }
     }
-
-    /// Returns a `BaudRate` instance for 115200 baud
-    ///
-    /// # Limitations
-    ///
-    /// This function assumes the default configuration for the main clock,
-    /// namely that the IRC running at 12 MHz is used. If you have made any
-    /// changes to the main clock configuration, please don't use this function
-    /// and create a `BaudRate` manually instead.
-    pub fn baud_115200(uartfrg: &'frg mut UARTFRG<'frg>) -> Self {
-        // The common peripheral clock for all UART units, U_PCLK, needs to be
-        // set to 16 times the desired baud rate. This results in a frequency of
-        // 1843200 Hz for U_PLCK.
-        //
-        // We assume the main clock runs at 12 Mhz. To get close to the desired
-        // frequency for U_PLCK, we divide that by 6 using UARTCLKDIV, resulting
-        // in a frequency of 2 Mhz.
-        //
-        // To get to the desired 1843200 Hz, we need to further divide the
-        // frequency using the fractional baud rate generator. The fractional
-        // baud rate generator divides the frequency by `1 + MULT/DIV`.
-        //
-        // DIV must always be 256. To achieve this, we need to set the
-        // UARTFRGDIV to 0xff. MULT can then be fine-tuned to get as close as
-        // possible to the desired value. We choose the value 22, which we write
-        // into UARTFRGMULT.
-        //
-        // Finally, we can set an additional divider value for the UART unit by
-        // writing to the BRG register. As we are already close enough to the
-        // desired value, we write 0, resulting in no further division.
-        //
-        // All of this is somewhat explained in the user manual, section 13.3.1.
-        uartfrg.set_clkdiv(6);
-        uartfrg.set_frgmult(22);
-        uartfrg.set_frgdiv(0xff);
-
-        BaudRate::new(uartfrg, 0)
-    }
 }
 
 

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -359,7 +359,7 @@ impl Peripheral for lpc82x::USART2 {
 /// [`frg_div`]: #structfield.frg_div
 /// [`brg_val`]: #structfield.brg_val
 pub struct BaudRate<'frg> {
-    _uartfrg: &'frg mut UARTFRG<'frg>,
+    _uartfrg: &'frg UARTFRG<'frg>,
 
     /// USART Baud Rate Generator divider value
     ///
@@ -369,7 +369,7 @@ pub struct BaudRate<'frg> {
 
 impl<'frg> BaudRate<'frg> {
     /// Create a `BaudRate` instance by providing the register values
-    pub fn new(uartfrg : &'frg mut UARTFRG<'frg>, brg_val : u16) -> Self {
+    pub fn new(uartfrg : &'frg UARTFRG<'frg>, brg_val : u16) -> Self {
         Self {
             _uartfrg: uartfrg,
             brg_val : brg_val,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -369,25 +369,40 @@ pub struct BaudRate {
     /// USART clock divider value
     ///
     /// See user manual, section 5.6.15.
-    pub clk_div: UartClkDiv,
+    clk_div: UartClkDiv,
 
     /// USART fractional generator multiplier value
     ///
     /// See user manual, section 5.6.20.
-    pub frg_mult: UartFrgMult,
+    frg_mult: UartFrgMult,
 
     /// USART fractional generator divider value
     ///
     /// See user manual, section 5.6.19.
-    pub frg_div: UartFrgDiv,
+    frg_div: UartFrgDiv,
 
     /// USART Baud Rate Generator divider value
     ///
     /// See user manual, section 13.6.9.
-    pub brg_val: u16,
+    brg_val: u16,
 }
 
 impl BaudRate {
+    /// Create a `BaudRate` instance by providing the register values
+    pub fn new(
+        clk_div : UartClkDiv,
+        frg_mult: UartFrgMult,
+        frg_div : UartFrgDiv,
+        brg_val : u16,
+    ) -> Self {
+        Self {
+            clk_div : clk_div,
+            frg_mult: frg_mult,
+            frg_div : frg_div,
+            brg_val : brg_val,
+        }
+    }
+
     /// Returns a `BaudRate` instance for 115200 baud
     ///
     /// # Limitations
@@ -419,12 +434,12 @@ impl BaudRate {
         // desired value, we write 0, resulting in no further division.
         //
         // All of this is somewhat explained in the user manual, section 13.3.1.
-        BaudRate {
-            clk_div : UartClkDiv(6),
-            frg_mult: UartFrgMult(22),
-            frg_div : UartFrgDiv(0xff),
-            brg_val : 0,
-        }
+        BaudRate::new(
+            UartClkDiv(6),
+            UartFrgMult(22),
+            UartFrgDiv(0xff),
+            0,
+        )
     }
 }
 

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -99,7 +99,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
         swm.assign_pin::<UsartX::Rx, Rx>();
         swm.assign_pin::<UsartX::Tx, Tx>();
 
-        self.usart.brg.write(|w| unsafe { w.brgval().bits(baud_rate.brg_val) });
+        self.usart.brg.write(|w| unsafe { w.brgval().bits(baud_rate.brgval) });
 
         // Disable USART peripheral before writing configuration. This is
         // required, according to the user manual, section 13.6.1.
@@ -350,7 +350,7 @@ pub struct BaudRate<'frg> {
     /// USART Baud Rate Generator divider value
     ///
     /// See user manual, section 13.6.9.
-    brg_val: u16,
+    brgval: u16,
 }
 
 impl<'frg> BaudRate<'frg> {
@@ -374,7 +374,7 @@ impl<'frg> BaudRate<'frg> {
     pub fn new(uartfrg : &'frg UARTFRG<'frg>, brgval : u16) -> Self {
         Self {
             _uartfrg: uartfrg,
-            brg_val : brgval,
+            brgval  : brgval,
         }
     }
 }

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -371,10 +371,10 @@ impl<'frg> BaudRate<'frg> {
     /// forth.
     ///
     /// [`UARTFRG`]: ../syscon/struct.UARTFRG.html
-    pub fn new(uartfrg : &'frg UARTFRG<'frg>, brg_val : u16) -> Self {
+    pub fn new(uartfrg : &'frg UARTFRG<'frg>, brgval : u16) -> Self {
         Self {
             _uartfrg: uartfrg,
-            brg_val : brg_val,
+            brg_val : brgval,
         }
     }
 }


### PR DESCRIPTION
Makes the API for controlling UART baud rates safe by making it impossible to change a baud rate once it is being used for a USART peripheral. Closes #7 because the safety aspects mentioned there have been addressed. A follow-up issue will be opened for the convenience aspects that haven't been addressed by this pull request.