### PR TITLE
Lay groundwork for SWM API safety improvements

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -8,7 +8,6 @@ use lpc82x;
 use ::{
     swm,
     syscon,
-    SWM,
 };
 use init_state::{
     self,
@@ -86,7 +85,7 @@ pub trait PinName {
     const MASK: u32;
 
     /// Disables all fixed functions for the given pin
-    fn disable_fixed_functions(swm: &mut SWM)
+    fn disable_fixed_functions(swm: &mut swm::Api)
         where Self: Sized;
 }
 
@@ -117,7 +116,7 @@ macro_rules! pins {
                 const ID  : u8  = $id;
                 const MASK: u32 = 0x1 << $id;
 
-                fn disable_fixed_functions(_swm: &mut SWM) {
+                fn disable_fixed_functions(_swm: &mut swm::Api) {
                     $(_swm.disable_fixed_function::<swm::$fixed_function>();)*
                 }
             }
@@ -169,7 +168,7 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     ///
     /// Disables the fixed function of the given pin (thus making it available
     /// for GPIO) and sets the GPIO direction to output.
-    pub fn set_pin_to_output(&mut self, swm: &mut SWM) {
+    pub fn set_pin_to_output(&mut self, swm: &mut swm::Api) {
         T::disable_fixed_functions(swm);
 
         self.gpio.gpio.dirset0.write(|w|

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -85,7 +85,10 @@ pub trait PinName {
     const MASK: u32;
 
     /// Disables all fixed functions for the given pin
-    fn disable_fixed_functions(swm: &mut swm::Api)
+    fn disable_fixed_functions(
+        _swm            : &mut swm::Api,
+        _fixed_functions: &mut swm::FixedFunctions,
+    )
         where Self: Sized;
 }
 
@@ -116,8 +119,14 @@ macro_rules! pins {
                 const ID  : u8  = $id;
                 const MASK: u32 = 0x1 << $id;
 
-                fn disable_fixed_functions(_swm: &mut swm::Api) {
-                    $(_swm.disable_fixed_function::<swm::$fixed_function>();)*
+                fn disable_fixed_functions(
+                    _swm            : &mut swm::Api,
+                    _fixed_functions: &mut swm::FixedFunctions,
+                ) {
+                    #[allow(unused_imports)]
+                    use swm::FixedFunction;
+
+                    $(_fixed_functions.$fixed_function.disable(_swm);)*
                 }
             }
         )*
@@ -125,30 +134,30 @@ macro_rules! pins {
 }
 
 pins!(
-    pio0_0 , PIO0_0 , 0x00, ACMP_I1;
-    pio0_1 , PIO0_1 , 0x01, ACMP_I2, CLKIN;
-    pio0_2 , PIO0_2 , 0x02, SWDIO;
-    pio0_3 , PIO0_3 , 0x03, SWCLK;
-    pio0_4 , PIO0_4 , 0x04, ADC_11;
-    pio0_5 , PIO0_5 , 0x05, RESETN;
-    pio0_6 , PIO0_6 , 0x06, VDDCMP, ADC_1;
-    pio0_7 , PIO0_7 , 0x07, ADC_0;
-    pio0_8 , PIO0_8 , 0x08, XTALIN;
-    pio0_9 , PIO0_9 , 0x09, XTALOUT;
-    pio0_10, PIO0_10, 0x0a, I2C0_SCL;
-    pio0_11, PIO0_11, 0x0b, I2C0_SDA;
+    pio0_0 , PIO0_0 , 0x00, acmp_i1;
+    pio0_1 , PIO0_1 , 0x01, acmp_i2, clkin;
+    pio0_2 , PIO0_2 , 0x02, swdio;
+    pio0_3 , PIO0_3 , 0x03, swclk;
+    pio0_4 , PIO0_4 , 0x04, adc_11;
+    pio0_5 , PIO0_5 , 0x05, resetn;
+    pio0_6 , PIO0_6 , 0x06, vddcmp, adc_1;
+    pio0_7 , PIO0_7 , 0x07, adc_0;
+    pio0_8 , PIO0_8 , 0x08, xtalin;
+    pio0_9 , PIO0_9 , 0x09, xtalout;
+    pio0_10, PIO0_10, 0x0a, i2c0_scl;
+    pio0_11, PIO0_11, 0x0b, i2c0_sda;
     pio0_12, PIO0_12, 0x0c;
-    pio0_13, PIO0_13, 0x0d, ADC_10;
-    pio0_14, PIO0_14, 0x0e, ACMP_I3, ADC_2;
+    pio0_13, PIO0_13, 0x0d, adc_10;
+    pio0_14, PIO0_14, 0x0e, acmp_i3, adc_2;
     pio0_15, PIO0_15, 0x0f;
     pio0_16, PIO0_16, 0x10;
-    pio0_17, PIO0_17, 0x11, ADC_9;
-    pio0_18, PIO0_18, 0x12, ADC_8;
-    pio0_19, PIO0_19, 0x13, ADC_7;
-    pio0_20, PIO0_20, 0x14, ADC_6;
-    pio0_21, PIO0_21, 0x15, ADC_5;
-    pio0_22, PIO0_22, 0x16, ADC_4;
-    pio0_23, PIO0_23, 0x17, ACMP_I4, ADC_3;
+    pio0_17, PIO0_17, 0x11, adc_9;
+    pio0_18, PIO0_18, 0x12, adc_8;
+    pio0_19, PIO0_19, 0x13, adc_7;
+    pio0_20, PIO0_20, 0x14, adc_6;
+    pio0_21, PIO0_21, 0x15, adc_5;
+    pio0_22, PIO0_22, 0x16, adc_4;
+    pio0_23, PIO0_23, 0x17, acmp_i4, adc_3;
     pio0_24, PIO0_24, 0x18;
     pio0_25, PIO0_25, 0x19;
     pio0_26, PIO0_26, 0x1a;
@@ -168,8 +177,11 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     ///
     /// Disables the fixed function of the given pin (thus making it available
     /// for GPIO) and sets the GPIO direction to output.
-    pub fn set_pin_to_output(&mut self, swm: &mut swm::Api) {
-        T::disable_fixed_functions(swm);
+    pub fn set_pin_to_output(&mut self,
+        swm            : &mut swm::Api,
+        fixed_functions: &mut swm::FixedFunctions,
+    ) {
+        T::disable_fixed_functions(swm, fixed_functions);
 
         self.gpio.gpio.dirset0.write(|w|
             unsafe { w.dirsetp().bits(T::MASK) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing it will actually lead to compile-time errors.
 //! let mut gpio = peripherals.gpio.init(&mut syscon);
-//! let mut swm  = peripherals.swm.init(&mut syscon);
+//! let mut swm  = peripherals.swm.api.init(&mut syscon);
 //! let mut wkt  = peripherals.wkt.init(&mut syscon);
 //!
 //! // We're going to need a clock for sleeping. Let's use the IRC-derived clock
@@ -497,7 +497,7 @@ pub struct Peripherals<'system> {
     pub pmu: PMU<'system>,
 
     /// Switch matrix (SWM)
-    pub swm: SWM<'system, init_state::Unknown>,
+    pub swm: SWM<'system>,
 
     /// System configuration (SYSCON)
     pub syscon: SYSCON<'system>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@
 //!
 //! // Initialize the peripherals. This is unsafe, because we're only allowed to
 //! // create one instance on `Peripherals`.
-//! let peripherals = unsafe { Peripherals::new() };
+//! let mut peripherals = unsafe { Peripherals::new() };
 //!
 //! // Let's save some peripherals in local variables for convenience. This one
 //! // here doesn't require initialization.
@@ -158,7 +158,7 @@
 //! let mut pio0_3 = gpio.pins().pio0_3;
 //!
 //! // Set pin direction to output, so we can use it to blink an LED.
-//! pio0_3.set_pin_to_output(&mut swm);
+//! pio0_3.set_pin_to_output(&mut swm, &mut peripherals.swm.fixed_functions);
 //!
 //! // Let's already initialize the durations that we're going to sleep for
 //! // between changing the LED state. We do this by specifying the number of

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -195,7 +195,7 @@ pub trait FixedFunction {
 }
 
 macro_rules! fixed_functions {
-    ($($fixed_function:ident, $field:ident;)*) => {
+    ($($type:ident, $field:ident;)*) => {
         $(
             /// Represents a fixed function
             ///
@@ -205,9 +205,9 @@ macro_rules! fixed_functions {
             /// [`SWM::enable_fixed_function`]: struct.SWM.html#method.enable_fixed_function
             /// [`SWM::disable_fixed_function`]: struct.SWM.html#method.disable_fixed_function
             #[allow(non_camel_case_types)]
-            pub struct $fixed_function;
+            pub struct $type;
 
-            impl FixedFunction for $fixed_function {
+            impl FixedFunction for $type {
                 fn enable(w: &mut pinenable0::W) -> &mut pinenable0::W {
                     w.$field().clear_bit()
                 }

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -20,14 +20,29 @@ use syscon;
 /// [`lpc82x::SWM`] directly, unless you know what you're doing.
 ///
 /// [`lpc82x::SWM`]: ../../lpc82x/struct.SWM.html
-pub struct SWM<'swm, State: InitState = init_state::Initialized> {
+pub struct SWM<'swm> {
+    /// Main SWM API
+    pub api: Api<'swm, init_state::Unknown>,
+}
+
+impl<'swm> SWM<'swm> {
+    pub(crate) fn new(swm: &'swm lpc82x::SWM) -> Self {
+        SWM {
+            api: Api::new(swm),
+        }
+    }
+}
+
+
+/// Main API of the SWM peripheral
+pub struct Api<'swm, State: InitState = init_state::Initialized> {
     swm   : &'swm lpc82x::SWM,
     _state: State,
 }
 
-impl<'swm> SWM<'swm, init_state::Unknown> {
+impl<'swm> Api<'swm, init_state::Unknown> {
     pub(crate) fn new(swm: &'swm lpc82x::SWM) -> Self {
-        SWM {
+        Api {
             swm   : swm,
             _state: init_state::Unknown,
         }
@@ -35,18 +50,18 @@ impl<'swm> SWM<'swm, init_state::Unknown> {
 
     /// Initialize the switch matrix
     pub fn init(mut self, syscon: &mut syscon::Api)
-        -> SWM<'swm, init_state::Initialized>
+        -> Api<'swm, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.swm);
 
-        SWM {
+        Api {
             swm   : self.swm,
             _state: init_state::Initialized,
         }
     }
 }
 
-impl<'swm> SWM<'swm> {
+impl<'swm> Api<'swm> {
     /// Assigns a movable function to a pin
     ///
     /// # Limitations

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -4,6 +4,20 @@
 
 
 use lpc82x;
+use lpc82x::swm::{
+    PINASSIGN0,
+    PINASSIGN1,
+    PINASSIGN2,
+    PINASSIGN3,
+    PINASSIGN4,
+    PINASSIGN5,
+    PINASSIGN6,
+    PINASSIGN7,
+    PINASSIGN8,
+    PINASSIGN9,
+    PINASSIGN10,
+    PINASSIGN11,
+};
 
 use gpio::PinName;
 use init_state::{
@@ -24,7 +38,7 @@ pub struct SWM<'swm> {
     pub api: Api<'swm, init_state::Unknown>,
 
     /// Movable functions
-    pub movable_functions: MovableFunctions,
+    pub movable_functions: MovableFunctions<'swm>,
 
     /// Fixed functions
     pub fixed_functions: FixedFunctions,
@@ -34,7 +48,7 @@ impl<'swm> SWM<'swm> {
     pub(crate) fn new(swm: &'swm lpc82x::SWM) -> Self {
         SWM {
             api              : Api::new(swm),
-            movable_functions: MovableFunctions::new(),
+            movable_functions: MovableFunctions::new(swm),
             fixed_functions  : FixedFunctions::new(),
         }
     }
@@ -82,17 +96,25 @@ pub trait MovableFunction {
 }
 
 macro_rules! movable_functions {
-    ($($field:ident, $type:ident, $reg_name:ident, $reg_field:ident;)*) => {
+    (
+        $(
+            $field:ident,
+            $type:ident,
+            $reg_type:ident,
+            $reg_name:ident,
+            $reg_field:ident;
+        )*
+    ) => {
         /// Provides access to all movable functions
         #[allow(missing_docs)]
-        pub struct MovableFunctions {
-            $(pub $field: $type,)*
+        pub struct MovableFunctions<'swm> {
+            $(pub $field: $type<'swm>,)*
         }
 
-        impl MovableFunctions {
-            fn new() -> Self {
+        impl<'swm> MovableFunctions<'swm> {
+            fn new(swm: &'swm lpc82x::SWM) -> Self {
                 MovableFunctions {
-                    $($field: $type,)*
+                    $($field: $type(&swm.$reg_name),)*
                 }
             }
         }
@@ -101,11 +123,14 @@ macro_rules! movable_functions {
         $(
             /// Represents a movable function
             #[allow(non_camel_case_types)]
-            pub struct $type;
+            pub struct $type<'swm>(&'swm $reg_type);
 
-            impl MovableFunction for $type {
-                fn assign<P: PinName>(&mut self, swm: &mut Api) {
-                    swm.swm.$reg_name.modify(|_, w|
+            impl<'swm> MovableFunction for $type<'swm> {
+                fn assign<P: PinName>(&mut self, _swm: &mut Api) {
+                    // We're not using the `_swm` argument, but we require it,
+                    // because the SWM needs to be clocked for this to work.
+
+                    self.0.modify(|_, w|
                         unsafe { w.$reg_field().bits(P::ID)
                     })
                 }
@@ -115,54 +140,54 @@ macro_rules! movable_functions {
 }
 
 movable_functions!(
-    u0_txd       , U0_TXD       , pinassign0 , u0_txd_o;
-    u0_rxd       , U0_RXD       , pinassign0 , u0_rxd_i;
-    u0_rts       , U0_RTS       , pinassign0 , u0_rts_o;
-    u0_cts       , U0_CTS       , pinassign0 , u0_cts_i;
-    u0_sclk      , U0_SCLK      , pinassign1 , u0_sclk_io;
-    u1_txd       , U1_TXD       , pinassign1 , u1_txd_o;
-    u1_rxd       , U1_RXD       , pinassign1 , u1_rxd_i;
-    u1_rts       , U1_RTS       , pinassign1 , u1_rts_o;
-    u1_cts       , U1_CTS       , pinassign2 , u1_cts_i;
-    u1_sclk      , U1_SCLK      , pinassign2 , u1_sclk_io;
-    u2_txd       , U2_TXD       , pinassign2 , u2_txd_o;
-    u2_rxd       , U2_RXD       , pinassign2 , u2_rxd_i;
-    u2_rts       , U2_RTS       , pinassign3 , u2_rts_o;
-    u2_cts       , U2_CTS       , pinassign3 , u2_cts_i;
-    u2_sclk      , U2_SCLK      , pinassign3 , u2_sclk_io;
-    spi0_sck     , SPI0_SCK     , pinassign3 , spi0_sck_io;
-    spi0_mosi    , SPI0_MOSI    , pinassign4 , spi0_mosi_io;
-    spi0_miso    , SPI0_MISO    , pinassign4 , spi0_miso_io;
-    spi0_ssel0   , SPI0_SSEL0   , pinassign4 , spi0_ssel0_io;
-    spi0_ssek1   , SPI0_SSEL1   , pinassign4 , spi0_ssel1_io;
-    spi0_ssel2   , SPI0_SSEL2   , pinassign5 , spi0_ssel2_io;
-    spi0_ssel3   , SPI0_SSEL3   , pinassign5 , spi0_ssel3_io;
-    spi1_sck     , SPI1_SCK     , pinassign5 , spi1_sck_io;
-    spi1_mosi    , SPI1_MOSI    , pinassign5 , spi1_mosi_io;
-    spi1_miso    , SPI1_MISO    , pinassign6 , spi1_miso_io;
-    spi1_ssel0   , SPI1_SSEL0   , pinassign6 , spi1_ssel0_io;
-    spi1_ssel1   , SPI1_SSEL1   , pinassign6 , spi1_ssel1_io;
-    sct_pin0     , SCT_PIN0     , pinassign6 , sct_in0_i;
-    sct_pin1     , SCT_PIN1     , pinassign7 , sct_in1_i;
-    sct_pin2     , SCT_PIN2     , pinassign7 , sct_in2_i;
-    sct_pin3     , SCT_PIN3     , pinassign7 , sct_in3_i;
-    sct_out0     , SCT_OUT0     , pinassign7 , sct_out0_o;
-    sct_out1     , SCT_OUT1     , pinassign8 , sct_out1_o;
-    sct_out2     , SCT_OUT2     , pinassign8 , sct_out2_o;
-    sct_out3     , SCT_OUT3     , pinassign8 , sct_out3_o;
-    sct_out4     , SCT_OUT4     , pinassign8 , sct_out4_o;
-    sct_out5     , SCT_OUT5     , pinassign9 , sct_out5_o;
-    i2c1_sda     , I2C1_SDA     , pinassign9 , i2c1_sda_io;
-    i2c1_scl     , I2C1_SCL     , pinassign9 , i2c1_scl_io;
-    i2c2_sda     , I2C2_SDA     , pinassign9 , i2c2_sda_io;
-    i2c2_scl     , I2C2_SCL     , pinassign10, i2c2_scl_io;
-    i2c3_sda     , I2C3_SDA     , pinassign10, i2c3_sda_io;
-    i2c3_scl     , I2C3_SCL     , pinassign10, i2c3_scl_io;
-    adc_pintrig0 , ADC_PINTRIG0 , pinassign10, adc_pintrig0_i;
-    acd_pintrig1 , ADC_PINTRIG1 , pinassign11, adc_pintrig1_i;
-    acmp_o       , ACMP_O       , pinassign11, acmp_o_o;
-    clkout       , CLKOUT       , pinassign11, clkout_o;
-    gpio_int_bmat, GPIO_INT_BMAT, pinassign11, gpio_int_bmat_o;
+    u0_txd       , U0_TXD       , PINASSIGN0 , pinassign0 , u0_txd_o;
+    u0_rxd       , U0_RXD       , PINASSIGN0 , pinassign0 , u0_rxd_i;
+    u0_rts       , U0_RTS       , PINASSIGN0 , pinassign0 , u0_rts_o;
+    u0_cts       , U0_CTS       , PINASSIGN0 , pinassign0 , u0_cts_i;
+    u0_sclk      , U0_SCLK      , PINASSIGN1 , pinassign1 , u0_sclk_io;
+    u1_txd       , U1_TXD       , PINASSIGN1 , pinassign1 , u1_txd_o;
+    u1_rxd       , U1_RXD       , PINASSIGN1 , pinassign1 , u1_rxd_i;
+    u1_rts       , U1_RTS       , PINASSIGN1 , pinassign1 , u1_rts_o;
+    u1_cts       , U1_CTS       , PINASSIGN2 , pinassign2 , u1_cts_i;
+    u1_sclk      , U1_SCLK      , PINASSIGN2 , pinassign2 , u1_sclk_io;
+    u2_txd       , U2_TXD       , PINASSIGN2 , pinassign2 , u2_txd_o;
+    u2_rxd       , U2_RXD       , PINASSIGN2 , pinassign2 , u2_rxd_i;
+    u2_rts       , U2_RTS       , PINASSIGN3 , pinassign3 , u2_rts_o;
+    u2_cts       , U2_CTS       , PINASSIGN3 , pinassign3 , u2_cts_i;
+    u2_sclk      , U2_SCLK      , PINASSIGN3 , pinassign3 , u2_sclk_io;
+    spi0_sck     , SPI0_SCK     , PINASSIGN3 , pinassign3 , spi0_sck_io;
+    spi0_mosi    , SPI0_MOSI    , PINASSIGN4 , pinassign4 , spi0_mosi_io;
+    spi0_miso    , SPI0_MISO    , PINASSIGN4 , pinassign4 , spi0_miso_io;
+    spi0_ssel0   , SPI0_SSEL0   , PINASSIGN4 , pinassign4 , spi0_ssel0_io;
+    spi0_ssek1   , SPI0_SSEL1   , PINASSIGN4 , pinassign4 , spi0_ssel1_io;
+    spi0_ssel2   , SPI0_SSEL2   , PINASSIGN5 , pinassign5 , spi0_ssel2_io;
+    spi0_ssel3   , SPI0_SSEL3   , PINASSIGN5 , pinassign5 , spi0_ssel3_io;
+    spi1_sck     , SPI1_SCK     , PINASSIGN5 , pinassign5 , spi1_sck_io;
+    spi1_mosi    , SPI1_MOSI    , PINASSIGN5 , pinassign5 , spi1_mosi_io;
+    spi1_miso    , SPI1_MISO    , PINASSIGN6 , pinassign6 , spi1_miso_io;
+    spi1_ssel0   , SPI1_SSEL0   , PINASSIGN6 , pinassign6 , spi1_ssel0_io;
+    spi1_ssel1   , SPI1_SSEL1   , PINASSIGN6 , pinassign6 , spi1_ssel1_io;
+    sct_pin0     , SCT_PIN0     , PINASSIGN6 , pinassign6 , sct_in0_i;
+    sct_pin1     , SCT_PIN1     , PINASSIGN7 , pinassign7 , sct_in1_i;
+    sct_pin2     , SCT_PIN2     , PINASSIGN7 , pinassign7 , sct_in2_i;
+    sct_pin3     , SCT_PIN3     , PINASSIGN7 , pinassign7 , sct_in3_i;
+    sct_out0     , SCT_OUT0     , PINASSIGN7 , pinassign7 , sct_out0_o;
+    sct_out1     , SCT_OUT1     , PINASSIGN8 , pinassign8 , sct_out1_o;
+    sct_out2     , SCT_OUT2     , PINASSIGN8 , pinassign8 , sct_out2_o;
+    sct_out3     , SCT_OUT3     , PINASSIGN8 , pinassign8 , sct_out3_o;
+    sct_out4     , SCT_OUT4     , PINASSIGN8 , pinassign8 , sct_out4_o;
+    sct_out5     , SCT_OUT5     , PINASSIGN9 , pinassign9 , sct_out5_o;
+    i2c1_sda     , I2C1_SDA     , PINASSIGN9 , pinassign9 , i2c1_sda_io;
+    i2c1_scl     , I2C1_SCL     , PINASSIGN9 , pinassign9 , i2c1_scl_io;
+    i2c2_sda     , I2C2_SDA     , PINASSIGN9 , pinassign9 , i2c2_sda_io;
+    i2c2_scl     , I2C2_SCL     , PINASSIGN10, pinassign10, i2c2_scl_io;
+    i2c3_sda     , I2C3_SDA     , PINASSIGN10, pinassign10, i2c3_sda_io;
+    i2c3_scl     , I2C3_SCL     , PINASSIGN10, pinassign10, i2c3_scl_io;
+    adc_pintrig0 , ADC_PINTRIG0 , PINASSIGN10, pinassign10, adc_pintrig0_i;
+    acd_pintrig1 , ADC_PINTRIG1 , PINASSIGN11, pinassign11, adc_pintrig1_i;
+    acmp_o       , ACMP_O       , PINASSIGN11, pinassign11, acmp_o_o;
+    clkout       , CLKOUT       , PINASSIGN11, pinassign11, clkout_o;
+    gpio_int_bmat, GPIO_INT_BMAT, PINASSIGN11, pinassign11, gpio_int_bmat_o;
 );
 
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -94,6 +94,16 @@ pub trait MovableFunction {
     /// currently used for something else. The HAL user needs to make sure that
     /// this assignment doesn't conflict with any other uses of the pin.
     fn assign<P: PinName>(&mut self, swm: &mut Api);
+
+    /// Unassign the movable function
+    ///
+    /// # Limitations
+    ///
+    /// This method can be used to unassign a movable function from a pin, while
+    /// that pin is being used by some other parts of the code. The HAL user
+    /// needs to make sure not to unassign any functions that other code relies
+    /// on.
+    fn unassign<P: PinName>(&mut self, swm: &mut Api);
 }
 
 macro_rules! movable_functions {
@@ -134,6 +144,15 @@ macro_rules! movable_functions {
                     self.0.modify(|_, w|
                         unsafe { w.$reg_field().bits(P::ID)
                     })
+                }
+
+                fn unassign<P: PinName>(&mut self, _swm: &mut Api) {
+                    // We're not using the `_swm` argument, but we require it,
+                    // because the SWM needs to be clocked for this to work.
+
+                    self.0.modify(|_, w|
+                        unsafe { w.$reg_field().bits(0xff) }
+                    )
                 }
             }
         )*

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -194,52 +194,56 @@ pub trait FixedFunction {
     fn disable(w: &mut pinenable0::W) -> &mut pinenable0::W;
 }
 
-macro_rules! impl_fixed_function {
-    ($fixed_function:ident, $field:ident) => {
-        /// Represents a fixed function
-        ///
-        /// Can be used with [`SWM::enable_fixed_function`] and
-        /// [`SWM::disable_fixed_function`].
-        ///
-        /// [`SWM::enable_fixed_function`]: struct.SWM.html#method.enable_fixed_function
-        /// [`SWM::disable_fixed_function`]: struct.SWM.html#method.disable_fixed_function
-        #[allow(non_camel_case_types)]
-        pub struct $fixed_function;
+macro_rules! fixed_functions {
+    ($($fixed_function:ident, $field:ident;)*) => {
+        $(
+            /// Represents a fixed function
+            ///
+            /// Can be used with [`SWM::enable_fixed_function`] and
+            /// [`SWM::disable_fixed_function`].
+            ///
+            /// [`SWM::enable_fixed_function`]: struct.SWM.html#method.enable_fixed_function
+            /// [`SWM::disable_fixed_function`]: struct.SWM.html#method.disable_fixed_function
+            #[allow(non_camel_case_types)]
+            pub struct $fixed_function;
 
-        impl FixedFunction for $fixed_function {
-            fn enable(w: &mut pinenable0::W) -> &mut pinenable0::W {
-                w.$field().clear_bit()
-            }
+            impl FixedFunction for $fixed_function {
+                fn enable(w: &mut pinenable0::W) -> &mut pinenable0::W {
+                    w.$field().clear_bit()
+                }
 
-            fn disable(w: &mut pinenable0::W) -> &mut pinenable0::W {
-                w.$field().set_bit()
+                fn disable(w: &mut pinenable0::W) -> &mut pinenable0::W {
+                    w.$field().set_bit()
+                }
             }
-        }
+        )*
     }
 }
 
-impl_fixed_function!(ACMP_I1 , acmp_i1 );
-impl_fixed_function!(ACMP_I2 , acmp_i2 );
-impl_fixed_function!(ACMP_I3 , acmp_i3 );
-impl_fixed_function!(ACMP_I4 , acmp_i4 );
-impl_fixed_function!(SWCLK   , swclk   );
-impl_fixed_function!(SWDIO   , swdio   );
-impl_fixed_function!(XTALIN  , xtalin  );
-impl_fixed_function!(XTALOUT , xtalout );
-impl_fixed_function!(RESETN  , resetn  );
-impl_fixed_function!(CLKIN   , clkin   );
-impl_fixed_function!(VDDCMP  , vddcmp  );
-impl_fixed_function!(I2C0_SDA, i2c0_sda);
-impl_fixed_function!(I2C0_SCL, i2c0_scl);
-impl_fixed_function!(ADC_0   , adc_0   );
-impl_fixed_function!(ADC_1   , adc_1   );
-impl_fixed_function!(ADC_2   , adc_2   );
-impl_fixed_function!(ADC_3   , adc_3   );
-impl_fixed_function!(ADC_4   , adc_4   );
-impl_fixed_function!(ADC_5   , adc_5   );
-impl_fixed_function!(ADC_6   , adc_6   );
-impl_fixed_function!(ADC_7   , adc_7   );
-impl_fixed_function!(ADC_8   , adc_8   );
-impl_fixed_function!(ADC_9   , adc_9   );
-impl_fixed_function!(ADC_10  , adc_10  );
-impl_fixed_function!(ADC_11  , adc_11  );
+fixed_functions!(
+    ACMP_I1 , acmp_i1;
+    ACMP_I2 , acmp_i2;
+    ACMP_I3 , acmp_i3;
+    ACMP_I4 , acmp_i4;
+    SWCLK   , swclk;
+    SWDIO   , swdio;
+    XTALIN  , xtalin;
+    XTALOUT , xtalout;
+    RESETN  , resetn;
+    CLKIN   , clkin;
+    VDDCMP  , vddcmp;
+    I2C0_SDA, i2c0_sda;
+    I2C0_SCL, i2c0_scl;
+    ADC_0   , adc_0;
+    ADC_1   , adc_1;
+    ADC_2   , adc_2;
+    ADC_3   , adc_3;
+    ADC_4   , adc_4;
+    ADC_5   , adc_5;
+    ADC_6   , adc_6;
+    ADC_7   , adc_7;
+    ADC_8   , adc_8;
+    ADC_9   , adc_9;
+    ADC_10  , adc_10;
+    ADC_11  , adc_11;
+);

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -23,12 +23,16 @@ use syscon;
 pub struct SWM<'swm> {
     /// Main SWM API
     pub api: Api<'swm, init_state::Unknown>,
+
+    /// Movable functions
+    pub movable_functions: MovableFunctions,
 }
 
 impl<'swm> SWM<'swm> {
     pub(crate) fn new(swm: &'swm lpc82x::SWM) -> Self {
         SWM {
-            api: Api::new(swm),
+            api              : Api::new(swm),
+            movable_functions: MovableFunctions::new(),
         }
     }
 }
@@ -102,7 +106,22 @@ pub trait MovableFunction {
 }
 
 macro_rules! movable_functions {
-    ($($type:ident, $register:ident, $reg_field:ident;)*) => {
+    ($($field:ident, $type:ident, $register:ident, $reg_field:ident;)*) => {
+        /// Provides access to all movable functions
+        #[allow(missing_docs)]
+        pub struct MovableFunctions {
+            $(pub $field: $type,)*
+        }
+
+        impl MovableFunctions {
+            fn new() -> Self {
+                MovableFunctions {
+                    $($field: $type,)*
+                }
+            }
+        }
+
+
         $(
             /// Represents a movable function
             ///
@@ -125,54 +144,54 @@ macro_rules! movable_functions {
 }
 
 movable_functions!(
-    U0_TXD       , pinassign0 , u0_txd_o;
-    U0_RXD       , pinassign0 , u0_rxd_i;
-    U0_RTS       , pinassign0 , u0_rts_o;
-    U0_CTS       , pinassign0 , u0_cts_i;
-    U0_SCLK      , pinassign1 , u0_sclk_io;
-    U1_TXD       , pinassign1 , u1_txd_o;
-    U1_RXD       , pinassign1 , u1_rxd_i;
-    U1_RTS       , pinassign1 , u1_rts_o;
-    U1_CTS       , pinassign2 , u1_cts_i;
-    U1_SCLK      , pinassign2 , u1_sclk_io;
-    U2_TXD       , pinassign2 , u2_txd_o;
-    U2_RXD       , pinassign2 , u2_rxd_i;
-    U2_RTS       , pinassign3 , u2_rts_o;
-    U2_CTS       , pinassign3 , u2_cts_i;
-    U2_SCLK      , pinassign3 , u2_sclk_io;
-    SPI0_SCK     , pinassign3 , spi0_sck_io;
-    SPI0_MOSI    , pinassign4 , spi0_mosi_io;
-    SPI0_MISO    , pinassign4 , spi0_miso_io;
-    SPI0_SSEL0   , pinassign4 , spi0_ssel0_io;
-    SPI0_SSEL1   , pinassign4 , spi0_ssel1_io;
-    SPI0_SSEL2   , pinassign5 , spi0_ssel2_io;
-    SPI0_SSEL3   , pinassign5 , spi0_ssel3_io;
-    SPI1_SCK     , pinassign5 , spi1_sck_io;
-    SPI1_MOSI    , pinassign5 , spi1_mosi_io;
-    SPI1_MISO    , pinassign6 , spi1_miso_io;
-    SPI1_SSEL0   , pinassign6 , spi1_ssel0_io;
-    SPI1_SSEL1   , pinassign6 , spi1_ssel1_io;
-    SCT_PIN0     , pinassign6 , sct_in0_i;
-    SCT_PIN1     , pinassign7 , sct_in1_i;
-    SCT_PIN2     , pinassign7 , sct_in2_i;
-    SCT_PIN3     , pinassign7 , sct_in3_i;
-    SCT_OUT0     , pinassign7 , sct_out0_o;
-    SCT_OUT1     , pinassign8 , sct_out1_o;
-    SCT_OUT2     , pinassign8 , sct_out2_o;
-    SCT_OUT3     , pinassign8 , sct_out3_o;
-    SCT_OUT4     , pinassign8 , sct_out4_o;
-    SCT_OUT5     , pinassign9 , sct_out5_o;
-    I2C1_SDA     , pinassign9 , i2c1_sda_io;
-    I2C1_SCL     , pinassign9 , i2c1_scl_io;
-    I2C2_SDA     , pinassign9 , i2c2_sda_io;
-    I2C2_SCL     , pinassign10, i2c2_scl_io;
-    I2C3_SDA     , pinassign10, i2c3_sda_io;
-    I2C3_SCL     , pinassign10, i2c3_scl_io;
-    ADC_PINTRIG0 , pinassign10, adc_pintrig0_i;
-    ADC_PINTRIG1 , pinassign11, adc_pintrig1_i;
-    ACMP_O       , pinassign11, acmp_o_o;
-    CLKOUT       , pinassign11, clkout_o;
-    GPIO_INT_BMAT, pinassign11, gpio_int_bmat_o;
+    u0_txd       , U0_TXD       , pinassign0 , u0_txd_o;
+    u0_rxd       , U0_RXD       , pinassign0 , u0_rxd_i;
+    u0_rts       , U0_RTS       , pinassign0 , u0_rts_o;
+    u0_cts       , U0_CTS       , pinassign0 , u0_cts_i;
+    u0_sclk      , U0_SCLK      , pinassign1 , u0_sclk_io;
+    u1_txd       , U1_TXD       , pinassign1 , u1_txd_o;
+    u1_rxd       , U1_RXD       , pinassign1 , u1_rxd_i;
+    u1_rts       , U1_RTS       , pinassign1 , u1_rts_o;
+    u1_cts       , U1_CTS       , pinassign2 , u1_cts_i;
+    u1_sclk      , U1_SCLK      , pinassign2 , u1_sclk_io;
+    u2_txd       , U2_TXD       , pinassign2 , u2_txd_o;
+    u2_rxd       , U2_RXD       , pinassign2 , u2_rxd_i;
+    u2_rts       , U2_RTS       , pinassign3 , u2_rts_o;
+    u2_cts       , U2_CTS       , pinassign3 , u2_cts_i;
+    u2_sclk      , U2_SCLK      , pinassign3 , u2_sclk_io;
+    spi0_sck     , SPI0_SCK     , pinassign3 , spi0_sck_io;
+    spi0_mosi    , SPI0_MOSI    , pinassign4 , spi0_mosi_io;
+    spi0_miso    , SPI0_MISO    , pinassign4 , spi0_miso_io;
+    spi0_ssel0   , SPI0_SSEL0   , pinassign4 , spi0_ssel0_io;
+    spi0_ssek1   , SPI0_SSEL1   , pinassign4 , spi0_ssel1_io;
+    spi0_ssel2   , SPI0_SSEL2   , pinassign5 , spi0_ssel2_io;
+    spi0_ssel3   , SPI0_SSEL3   , pinassign5 , spi0_ssel3_io;
+    spi1_sck     , SPI1_SCK     , pinassign5 , spi1_sck_io;
+    spi1_mosi    , SPI1_MOSI    , pinassign5 , spi1_mosi_io;
+    spi1_miso    , SPI1_MISO    , pinassign6 , spi1_miso_io;
+    spi1_ssel0   , SPI1_SSEL0   , pinassign6 , spi1_ssel0_io;
+    spi1_ssel1   , SPI1_SSEL1   , pinassign6 , spi1_ssel1_io;
+    sct_pin0     , SCT_PIN0     , pinassign6 , sct_in0_i;
+    sct_pin1     , SCT_PIN1     , pinassign7 , sct_in1_i;
+    sct_pin2     , SCT_PIN2     , pinassign7 , sct_in2_i;
+    sct_pin3     , SCT_PIN3     , pinassign7 , sct_in3_i;
+    sct_out0     , SCT_OUT0     , pinassign7 , sct_out0_o;
+    sct_out1     , SCT_OUT1     , pinassign8 , sct_out1_o;
+    sct_out2     , SCT_OUT2     , pinassign8 , sct_out2_o;
+    sct_out3     , SCT_OUT3     , pinassign8 , sct_out3_o;
+    sct_out4     , SCT_OUT4     , pinassign8 , sct_out4_o;
+    sct_out5     , SCT_OUT5     , pinassign9 , sct_out5_o;
+    i2c1_sda     , I2C1_SDA     , pinassign9 , i2c1_sda_io;
+    i2c1_scl     , I2C1_SCL     , pinassign9 , i2c1_scl_io;
+    i2c2_sda     , I2C2_SDA     , pinassign9 , i2c2_sda_io;
+    i2c2_scl     , I2C2_SCL     , pinassign10, i2c2_scl_io;
+    i2c3_sda     , I2C3_SDA     , pinassign10, i2c3_sda_io;
+    i2c3_scl     , I2C3_SCL     , pinassign10, i2c3_scl_io;
+    adc_pintrig0 , ADC_PINTRIG0 , pinassign10, adc_pintrig0_i;
+    acd_pintrig1 , ADC_PINTRIG1 , pinassign11, adc_pintrig1_i;
+    acmp_o       , ACMP_O       , pinassign11, acmp_o_o;
+    clkout       , CLKOUT       , pinassign11, clkout_o;
+    gpio_int_bmat, GPIO_INT_BMAT, pinassign11, gpio_int_bmat_o;
 );
 
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -87,7 +87,7 @@ pub trait MovableFunction {
 }
 
 macro_rules! movable_functions {
-    ($($movable_function:ident, $register:ident, $field:ident;)*) => {
+    ($($type:ident, $register:ident, $reg_field:ident;)*) => {
         $(
             /// Represents a movable function
             ///
@@ -96,12 +96,12 @@ macro_rules! movable_functions {
             ///
             /// [`SWM::assign_pin`]: struct.SWM.html#method.assign_pin
             #[allow(non_camel_case_types)]
-            pub struct $movable_function;
+            pub struct $type;
 
-            impl MovableFunction for $movable_function {
+            impl MovableFunction for $type {
                 fn assign_pin<P: PinName>(swm: &lpc82x::SWM) {
                     swm.$register.modify(|_, w|
-                        unsafe { w.$field().bits(P::ID)
+                        unsafe { w.$reg_field().bits(P::ID)
                     })
                 }
             }

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -26,6 +26,9 @@ pub struct SWM<'swm> {
 
     /// Movable functions
     pub movable_functions: MovableFunctions,
+
+    /// Fixed functions
+    pub fixed_functions: FixedFunctions,
 }
 
 impl<'swm> SWM<'swm> {
@@ -33,6 +36,7 @@ impl<'swm> SWM<'swm> {
         SWM {
             api              : Api::new(swm),
             movable_functions: MovableFunctions::new(),
+            fixed_functions  : FixedFunctions::new(),
         }
     }
 }
@@ -196,6 +200,21 @@ pub trait FixedFunction {
 
 macro_rules! fixed_functions {
     ($($type:ident, $field:ident;)*) => {
+        // Provides access to all fixed functions
+        #[allow(missing_docs)]
+        pub struct FixedFunctions {
+            $(pub $field: $type,)*
+        }
+
+        impl FixedFunctions {
+            fn new() -> Self {
+                FixedFunctions {
+                    $($field: $type,)*
+                }
+            }
+        }
+
+
         $(
             /// Represents a fixed function
             ///

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -82,7 +82,7 @@ pub trait MovableFunction {
 }
 
 macro_rules! movable_functions {
-    ($($field:ident, $type:ident, $register:ident, $reg_field:ident;)*) => {
+    ($($field:ident, $type:ident, $reg_name:ident, $reg_field:ident;)*) => {
         /// Provides access to all movable functions
         #[allow(missing_docs)]
         pub struct MovableFunctions {
@@ -105,7 +105,7 @@ macro_rules! movable_functions {
 
             impl MovableFunction for $type {
                 fn assign<P: PinName>(&mut self, swm: &mut Api) {
-                    swm.swm.$register.modify(|_, w|
+                    swm.swm.$reg_name.modify(|_, w|
                         unsafe { w.$reg_field().bits(P::ID)
                     })
                 }

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -86,75 +86,79 @@ pub trait MovableFunction {
     fn assign_pin<P: PinName>(swm: &lpc82x::SWM);
 }
 
-macro_rules! impl_movable_function {
-    ($movable_function:ident, $register:ident, $field:ident) => {
-        /// Represents a movable function
-        ///
-        /// Can be used with [`SWM::assign_pin`] to assign this movable function
-        /// to a pin.
-        ///
-        /// [`SWM::assign_pin`]: struct.SWM.html#method.assign_pin
-        #[allow(non_camel_case_types)]
-        pub struct $movable_function;
+macro_rules! movable_functions {
+    ($($movable_function:ident, $register:ident, $field:ident;)*) => {
+        $(
+            /// Represents a movable function
+            ///
+            /// Can be used with [`SWM::assign_pin`] to assign this movable
+            /// function to a pin.
+            ///
+            /// [`SWM::assign_pin`]: struct.SWM.html#method.assign_pin
+            #[allow(non_camel_case_types)]
+            pub struct $movable_function;
 
-        impl MovableFunction for $movable_function {
-            fn assign_pin<P: PinName>(swm: &lpc82x::SWM) {
-                swm.$register.modify(|_, w|
-                    unsafe { w.$field().bits(P::ID)
-                })
+            impl MovableFunction for $movable_function {
+                fn assign_pin<P: PinName>(swm: &lpc82x::SWM) {
+                    swm.$register.modify(|_, w|
+                        unsafe { w.$field().bits(P::ID)
+                    })
+                }
             }
-        }
+        )*
     }
 }
 
-impl_movable_function!(U0_TXD       , pinassign0 , u0_txd_o       );
-impl_movable_function!(U0_RXD       , pinassign0 , u0_rxd_i       );
-impl_movable_function!(U0_RTS       , pinassign0 , u0_rts_o       );
-impl_movable_function!(U0_CTS       , pinassign0 , u0_cts_i       );
-impl_movable_function!(U0_SCLK      , pinassign1 , u0_sclk_io     );
-impl_movable_function!(U1_TXD       , pinassign1 , u1_txd_o       );
-impl_movable_function!(U1_RXD       , pinassign1 , u1_rxd_i       );
-impl_movable_function!(U1_RTS       , pinassign1 , u1_rts_o       );
-impl_movable_function!(U1_CTS       , pinassign2 , u1_cts_i       );
-impl_movable_function!(U1_SCLK      , pinassign2 , u1_sclk_io     );
-impl_movable_function!(U2_TXD       , pinassign2 , u2_txd_o       );
-impl_movable_function!(U2_RXD       , pinassign2 , u2_rxd_i       );
-impl_movable_function!(U2_RTS       , pinassign3 , u2_rts_o       );
-impl_movable_function!(U2_CTS       , pinassign3 , u2_cts_i       );
-impl_movable_function!(U2_SCLK      , pinassign3 , u2_sclk_io     );
-impl_movable_function!(SPI0_SCK     , pinassign3 , spi0_sck_io    );
-impl_movable_function!(SPI0_MOSI    , pinassign4 , spi0_mosi_io   );
-impl_movable_function!(SPI0_MISO    , pinassign4 , spi0_miso_io   );
-impl_movable_function!(SPI0_SSEL0   , pinassign4 , spi0_ssel0_io  );
-impl_movable_function!(SPI0_SSEL1   , pinassign4 , spi0_ssel1_io  );
-impl_movable_function!(SPI0_SSEL2   , pinassign5 , spi0_ssel2_io  );
-impl_movable_function!(SPI0_SSEL3   , pinassign5 , spi0_ssel3_io  );
-impl_movable_function!(SPI1_SCK     , pinassign5 , spi1_sck_io    );
-impl_movable_function!(SPI1_MOSI    , pinassign5 , spi1_mosi_io   );
-impl_movable_function!(SPI1_MISO    , pinassign6 , spi1_miso_io   );
-impl_movable_function!(SPI1_SSEL0   , pinassign6 , spi1_ssel0_io  );
-impl_movable_function!(SPI1_SSEL1   , pinassign6 , spi1_ssel1_io  );
-impl_movable_function!(SCT_PIN0     , pinassign6 , sct_in0_i      );
-impl_movable_function!(SCT_PIN1     , pinassign7 , sct_in1_i      );
-impl_movable_function!(SCT_PIN2     , pinassign7 , sct_in2_i      );
-impl_movable_function!(SCT_PIN3     , pinassign7 , sct_in3_i      );
-impl_movable_function!(SCT_OUT0     , pinassign7 , sct_out0_o     );
-impl_movable_function!(SCT_OUT1     , pinassign8 , sct_out1_o     );
-impl_movable_function!(SCT_OUT2     , pinassign8 , sct_out2_o     );
-impl_movable_function!(SCT_OUT3     , pinassign8 , sct_out3_o     );
-impl_movable_function!(SCT_OUT4     , pinassign8 , sct_out4_o     );
-impl_movable_function!(SCT_OUT5     , pinassign9 , sct_out5_o     );
-impl_movable_function!(I2C1_SDA     , pinassign9 , i2c1_sda_io    );
-impl_movable_function!(I2C1_SCL     , pinassign9 , i2c1_scl_io    );
-impl_movable_function!(I2C2_SDA     , pinassign9 , i2c2_sda_io    );
-impl_movable_function!(I2C2_SCL     , pinassign10, i2c2_scl_io    );
-impl_movable_function!(I2C3_SDA     , pinassign10, i2c3_sda_io    );
-impl_movable_function!(I2C3_SCL     , pinassign10, i2c3_scl_io    );
-impl_movable_function!(ADC_PINTRIG0 , pinassign10, adc_pintrig0_i );
-impl_movable_function!(ADC_PINTRIG1 , pinassign11, adc_pintrig1_i );
-impl_movable_function!(ACMP_O       , pinassign11, acmp_o_o       );
-impl_movable_function!(CLKOUT       , pinassign11, clkout_o       );
-impl_movable_function!(GPIO_INT_BMAT, pinassign11, gpio_int_bmat_o);
+movable_functions!(
+    U0_TXD       , pinassign0 , u0_txd_o;
+    U0_RXD       , pinassign0 , u0_rxd_i;
+    U0_RTS       , pinassign0 , u0_rts_o;
+    U0_CTS       , pinassign0 , u0_cts_i;
+    U0_SCLK      , pinassign1 , u0_sclk_io;
+    U1_TXD       , pinassign1 , u1_txd_o;
+    U1_RXD       , pinassign1 , u1_rxd_i;
+    U1_RTS       , pinassign1 , u1_rts_o;
+    U1_CTS       , pinassign2 , u1_cts_i;
+    U1_SCLK      , pinassign2 , u1_sclk_io;
+    U2_TXD       , pinassign2 , u2_txd_o;
+    U2_RXD       , pinassign2 , u2_rxd_i;
+    U2_RTS       , pinassign3 , u2_rts_o;
+    U2_CTS       , pinassign3 , u2_cts_i;
+    U2_SCLK      , pinassign3 , u2_sclk_io;
+    SPI0_SCK     , pinassign3 , spi0_sck_io;
+    SPI0_MOSI    , pinassign4 , spi0_mosi_io;
+    SPI0_MISO    , pinassign4 , spi0_miso_io;
+    SPI0_SSEL0   , pinassign4 , spi0_ssel0_io;
+    SPI0_SSEL1   , pinassign4 , spi0_ssel1_io;
+    SPI0_SSEL2   , pinassign5 , spi0_ssel2_io;
+    SPI0_SSEL3   , pinassign5 , spi0_ssel3_io;
+    SPI1_SCK     , pinassign5 , spi1_sck_io;
+    SPI1_MOSI    , pinassign5 , spi1_mosi_io;
+    SPI1_MISO    , pinassign6 , spi1_miso_io;
+    SPI1_SSEL0   , pinassign6 , spi1_ssel0_io;
+    SPI1_SSEL1   , pinassign6 , spi1_ssel1_io;
+    SCT_PIN0     , pinassign6 , sct_in0_i;
+    SCT_PIN1     , pinassign7 , sct_in1_i;
+    SCT_PIN2     , pinassign7 , sct_in2_i;
+    SCT_PIN3     , pinassign7 , sct_in3_i;
+    SCT_OUT0     , pinassign7 , sct_out0_o;
+    SCT_OUT1     , pinassign8 , sct_out1_o;
+    SCT_OUT2     , pinassign8 , sct_out2_o;
+    SCT_OUT3     , pinassign8 , sct_out3_o;
+    SCT_OUT4     , pinassign8 , sct_out4_o;
+    SCT_OUT5     , pinassign9 , sct_out5_o;
+    I2C1_SDA     , pinassign9 , i2c1_sda_io;
+    I2C1_SCL     , pinassign9 , i2c1_scl_io;
+    I2C2_SDA     , pinassign9 , i2c2_sda_io;
+    I2C2_SCL     , pinassign10, i2c2_scl_io;
+    I2C3_SDA     , pinassign10, i2c3_sda_io;
+    I2C3_SCL     , pinassign10, i2c3_scl_io;
+    ADC_PINTRIG0 , pinassign10, adc_pintrig0_i;
+    ADC_PINTRIG1 , pinassign11, adc_pintrig1_i;
+    ACMP_O       , pinassign11, acmp_o_o;
+    CLKOUT       , pinassign11, clkout_o;
+    GPIO_INT_BMAT, pinassign11, gpio_int_bmat_o;
+);
 
 
 /// Implemented for types that represent movable functions

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -74,7 +74,7 @@ impl<'swm> Api<'swm> {
     /// currently used for something else. The HAL user needs to make sure that
     /// this assignment doesn't conflict with any other uses of the pin.
     pub fn assign_pin<F: MovableFunction, P: PinName>(&mut self) {
-        F::assign_pin::<P>(&self.swm);
+        F::assign::<P>(&self.swm);
     }
 
     /// Enables a fixed function
@@ -102,7 +102,7 @@ impl<'swm> Api<'swm> {
 /// trait won't be considered breaking changes.
 pub trait MovableFunction {
     /// Internal method to assign a pin to a movable function.
-    fn assign_pin<P: PinName>(swm: &lpc82x::SWM);
+    fn assign<P: PinName>(swm: &lpc82x::SWM);
 }
 
 macro_rules! movable_functions {
@@ -133,7 +133,7 @@ macro_rules! movable_functions {
             pub struct $type;
 
             impl MovableFunction for $type {
-                fn assign_pin<P: PinName>(swm: &lpc82x::SWM) {
+                fn assign<P: PinName>(swm: &lpc82x::SWM) {
                     swm.$register.modify(|_, w|
                         unsafe { w.$reg_field().bits(P::ID)
                     })

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -142,8 +142,8 @@ macro_rules! movable_functions {
                     // because the SWM needs to be clocked for this to work.
 
                     self.0.modify(|_, w|
-                        unsafe { w.$reg_field().bits(P::ID)
-                    })
+                        unsafe { w.$reg_field().bits(P::ID) }
+                    )
                 }
 
                 fn unassign<P: PinName>(&mut self, _swm: &mut Api) {

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -18,7 +18,10 @@ use init_state::{
     self,
     InitState,
 };
-use swm;
+use swm::{
+    self,
+    MovableFunction,
+};
 use syscon::{
     self,
     UARTFRG,
@@ -88,6 +91,8 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     pub fn init<Rx: PinName, Tx: PinName>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut syscon::Api,
+        rxd      : &mut UsartX::Rx,
+        txd      : &mut UsartX::Tx,
         swm      : &mut swm::Api,
     )
         -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !>
@@ -95,8 +100,8 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
         syscon.enable_clock(&mut self.usart);
         syscon.clear_reset(&mut self.usart);
 
-        swm.assign_pin::<UsartX::Rx, Rx>();
-        swm.assign_pin::<UsartX::Tx, Tx>();
+        rxd.assign::<Rx>(swm);
+        txd.assign::<Tx>(swm);
 
         self.usart.brg.write(|w| unsafe { w.brgval().bits(baud_rate.brgval) });
 

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -67,9 +67,9 @@ pub struct USART<
     _state: State,
 }
 
-impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
+impl<'usart, 'swm, UsartX> USART<'usart, UsartX, init_state::Unknown>
     where
-        UsartX            : Peripheral,
+        UsartX            : Peripheral<'swm>,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     pub(crate) fn new(usart: &'usart UsartX) -> Self {
@@ -166,7 +166,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
 
 impl<'usart, UsartX> USART<'usart, UsartX>
     where
-        UsartX            : Peripheral,
+        UsartX            : for<'a> Peripheral<'a>,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     /// Enables the USART interrupts
@@ -209,7 +209,7 @@ impl<'usart, UsartX> USART<'usart, UsartX>
 
 impl<'usart, UsartX> Read<u8> for USART<'usart, UsartX>
     where
-        UsartX            : Peripheral,
+        UsartX            : for<'a> Peripheral<'a>,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     type Error = Error;
@@ -254,7 +254,7 @@ impl<'usart, UsartX> Read<u8> for USART<'usart, UsartX>
 
 impl<'usart, UsartX> Write<u8> for USART<'usart, UsartX>
     where
-        UsartX            : Peripheral,
+        UsartX            : for<'a> Peripheral<'a>,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     type Error = !;
@@ -282,7 +282,7 @@ impl<'usart, UsartX> Write<u8> for USART<'usart, UsartX>
 
 impl<'usart, UsartX> blocking::Write<u8> for USART<'usart, UsartX>
     where
-        UsartX            : Peripheral,
+        UsartX            : for<'a> Peripheral<'a>,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     type Error = !;
@@ -304,7 +304,7 @@ impl<'usart, UsartX> blocking::Write<u8> for USART<'usart, UsartX>
 /// the other traits required are implemented for `&Self`. This should be
 /// resolved once we pick up some changes to upstream dependencies that are
 /// currently coming down the pipe.
-pub trait Peripheral:
+pub trait Peripheral<'swm>:
     Deref<Target = lpc82x::usart0::RegisterBlock>
     where
         for<'a> &'a Self: syscon::ClockControl,
@@ -320,25 +320,25 @@ pub trait Peripheral:
     type Tx: swm::MovableFunction;
 }
 
-impl Peripheral for lpc82x::USART0 {
+impl<'swm> Peripheral<'swm> for lpc82x::USART0 {
     const INTERRUPT: Interrupt = Interrupt::UART0;
 
-    type Rx = swm::U0_RXD;
-    type Tx = swm::U0_TXD;
+    type Rx = swm::U0_RXD<'swm>;
+    type Tx = swm::U0_TXD<'swm>;
 }
 
-impl Peripheral for lpc82x::USART1 {
+impl<'swm> Peripheral<'swm> for lpc82x::USART1 {
     const INTERRUPT: Interrupt = Interrupt::UART1;
 
-    type Rx = swm::U1_RXD;
-    type Tx = swm::U1_TXD;
+    type Rx = swm::U1_RXD<'swm>;
+    type Tx = swm::U1_TXD<'swm>;
 }
 
-impl Peripheral for lpc82x::USART2 {
+impl<'swm> Peripheral<'swm> for lpc82x::USART2 {
     const INTERRUPT: Interrupt = Interrupt::UART2;
 
-    type Rx = swm::U2_RXD;
-    type Tx = swm::U2_TXD;
+    type Rx = swm::U2_RXD<'swm>;
+    type Tx = swm::U2_TXD<'swm>;
 }
 
 

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -18,10 +18,7 @@ use init_state::{
     self,
     InitState,
 };
-use swm::{
-    self,
-    SWM,
-};
+use swm;
 use syscon::{
     self,
     UARTFRG,
@@ -91,7 +88,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     pub fn init<Rx: PinName, Tx: PinName>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut syscon::Api,
-        swm      : &mut SWM,
+        swm      : &mut swm::Api,
     )
         -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !>
     {


### PR DESCRIPTION
This pull request lays more groundwork for issue #2, a completely safe pin API, by reorganizing the SWM API.

I originally thought that adding type state to pin types would be enough to create a pin API that is safe at compile-time. Turns out I was wrong, as the switch matrix API is much more nuanced and powerful than I was aware of, and allows assigning multiple functions to the same pin.

I believe this can be modelled by also adding type state to each fixed or movable function. This requires each function to be represented by its own type, which is what this pull request does.