### PR TITLE
Update pin API

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -267,9 +267,6 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinName {
 
 impl<'gpio, T> Pin<T, pin_state::Gpio<'gpio>> where T: PinName {
     /// Sets pin direction to output
-    ///
-    /// Disables the fixed function of the given pin (thus making it available
-    /// for GPIO) and sets the GPIO direction to output.
     pub fn as_output(&mut self) {
         self.state.0.gpio.dirset0.write(|w|
             unsafe { w.dirsetp().bits(T::MASK) }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -50,7 +50,7 @@ impl<'gpio> GPIO<'gpio, init_state::Unknown> {
 
 impl<'gpio> GPIO<'gpio> {
     /// Provides access to all pins
-    pub fn pins(&self) -> Pins {
+    pub fn pins(&mut self) -> Pins {
         Pins::new(self)
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -105,7 +105,7 @@ macro_rules! pins {
         impl<'gpio> Pins<'gpio> {
             fn new(gpio: &'gpio GPIO<'gpio>) -> Self {
                 Pins {
-                    $($field: Pin { gpio: gpio, _ty: $type(()) },)*
+                    $($field: Pin { gpio: gpio, ty: $type(()) },)*
                 }
             }
         }
@@ -170,7 +170,7 @@ pins!(
 /// A pin that can be used for GPIO, fixed functions, or movable functions
 pub struct Pin<'gpio, T: PinName> {
     gpio: &'gpio GPIO<'gpio>,
-    _ty : T,
+    ty  : T,
 }
 
 impl<'gpio, T> Pin<'gpio, T> where T: PinName {
@@ -184,7 +184,7 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     pub fn assign_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
         where F: MovableFunction
     {
-        function.assign::<T>(&mut self._ty, swm);
+        function.assign::<T>(&mut self.ty, swm);
     }
 
     /// Unassign a movable function from the pin
@@ -197,7 +197,7 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     pub fn unassign_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
         where F: MovableFunction
     {
-        function.unassign::<T>(&mut self._ty, swm);
+        function.unassign::<T>(&mut self.ty, swm);
     }
 
     /// Sets pin direction to output

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -253,7 +253,7 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     ///
     /// Disables the fixed function of the given pin (thus making it available
     /// for GPIO) and sets the GPIO direction to output.
-    pub fn set_pin_to_output(&mut self) {
+    pub fn as_output(&mut self) {
         self.gpio.gpio.dirset0.write(|w|
             unsafe { w.dirsetp().bits(T::MASK) }
         )

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -227,16 +227,33 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
         function.unassign::<T>(&mut self.ty, swm);
     }
 
+    /// Makes this pin available for GPIO
+    ///
+    /// Disables all fixed functions of this pin, thereby making it available
+    /// for general-purpose I/O. It might be necessary to call this method, as
+    /// some pins have fixed functions enabled by default.
+    ///
+    /// # Limitations
+    ///
+    /// This method doesn't unsassign any movable functions that might be assign
+    /// to the pin. This is not a problem if you're using this method for the
+    /// initial initialization of the pin, as no movable functions are assigned
+    /// by default.
+    ///
+    /// If any movable functions have been assigned to the pin, please make sure
+    /// to disable them manually.
+    pub fn as_gpio_pin(&mut self,
+        fixed_functions: &mut swm::FixedFunctions,
+        swm            : &mut swm::Api,
+    ) {
+        self.ty.disable_fixed_functions(swm, fixed_functions);
+    }
+
     /// Sets pin direction to output
     ///
     /// Disables the fixed function of the given pin (thus making it available
     /// for GPIO) and sets the GPIO direction to output.
-    pub fn set_pin_to_output(&mut self,
-        swm            : &mut swm::Api,
-        fixed_functions: &mut swm::FixedFunctions,
-    ) {
-        self.ty.disable_fixed_functions(swm, fixed_functions);
-
+    pub fn set_pin_to_output(&mut self) {
         self.gpio.gpio.dirset0.write(|w|
             unsafe { w.dirsetp().bits(T::MASK) }
         )

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -128,7 +128,7 @@ macro_rules! pins {
                     #[allow(unused_imports)]
                     use swm::FixedFunction;
 
-                    $(_fixed_functions.$fixed_function.disable(_swm);)*
+                    $(_fixed_functions.$fixed_function.disable(self, _swm);)*
                 }
             }
         )*
@@ -182,15 +182,10 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     /// This method can be used to enable a fixed function for a pin that is
     /// currently used for something else. The HAL user needs to make sure that
     /// the fixed function doesn't conflict with any other uses of the pin.
-    ///
-    /// This method also doesn't check, whether the fixed function provided
-    /// actually belongs to this pin, so it can be used to enable fixed
-    /// functions of other pins. The user needs to make sure not to do that or,
-    /// at the very least, be intentional about it.
     pub fn enable_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
-        where F: FixedFunction
+        where F: FixedFunction<Pin=T>
     {
-        function.enable(swm);
+        function.enable(&mut self.ty, swm);
     }
 
     /// Disable the fixed function on this pin
@@ -200,15 +195,10 @@ impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     /// This method can be used to disable a fixed function while other code
     /// relies on that fixed function being enabled. The HAL user needs to make
     /// sure not to use this method in any way that breaks other code.
-    ///
-    /// This method also doesn't check, whether the fixed function provided
-    /// actually belongs to this pin, so it can be used to disable fixed
-    /// functions of other pins. The user needs to make sure not to do that or,
-    /// at the very least, be intentional about it.
     pub fn disable_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
-        where F: FixedFunction
+        where F: FixedFunction<Pin=T>
     {
-        function.disable(swm);
+        function.disable(&mut self.ty, swm);
     }
 
     /// Assign a movable function to the pin

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -5,14 +5,15 @@
 
 use lpc82x;
 
-use ::{
-    swm,
-    syscon,
-};
 use init_state::{
     self,
     InitState,
 };
+use swm::{
+    self,
+    MovableFunction,
+};
+use syscon;
 
 
 /// Interface to general-purpose I/O (GPIO)
@@ -173,6 +174,20 @@ pub struct Pin<'gpio, T: PinName> {
 }
 
 impl<'gpio, T> Pin<'gpio, T> where T: PinName {
+    /// Assign a movable function to the pin
+    pub fn assign_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
+        where F: MovableFunction
+    {
+        function.assign::<T>(swm);
+    }
+
+    /// Unassign a movable function from the pin
+    pub fn unassign_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
+        where F: MovableFunction
+    {
+        function.unassign::<T>(swm);
+    }
+
     /// Sets pin direction to output
     ///
     /// Disables the fixed function of the given pin (thus making it available

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -251,13 +251,23 @@ impl<'gpio, T> Pin<'gpio, T, pin_state::Unknown> where T: PinName {
     ///
     /// If any movable functions have been assigned to the pin, please make sure
     /// to disable them manually.
-    pub fn as_gpio_pin(&mut self,
+    pub fn as_gpio_pin(mut self,
         fixed_functions: &mut swm::FixedFunctions,
         swm            : &mut swm::Api,
-    ) {
+    )
+        -> Pin<'gpio, T, pin_state::Gpio>
+    {
         self.ty.disable_fixed_functions(swm, fixed_functions);
-    }
 
+        Pin {
+            gpio  : self.gpio,
+            ty    : self.ty,
+            _state: pin_state::Gpio,
+        }
+    }
+}
+
+impl<'gpio, T> Pin<'gpio, T, pin_state::Gpio> where T: PinName {
     /// Sets pin direction to output
     ///
     /// Disables the fixed function of the given pin (thus making it available
@@ -299,4 +309,8 @@ pub mod pin_state {
     /// initializized, this is the initial state of all pins.
     pub struct Unknown;
     impl PinState for Unknown {}
+
+    /// Marks a pin as being assigned to general-purpose I/O
+    pub struct Gpio;
+    impl PinState for Gpio {}
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -110,8 +110,8 @@ macro_rules! pins {
                 Pins {
                     $(
                         $field: Pin {
-                            ty    : $type(()),
-                            _state: pin_state::Unknown,
+                            ty   : $type(()),
+                            state: pin_state::Unknown,
                         },
                     )*
                 }
@@ -177,8 +177,8 @@ pins!(
 
 /// A pin that can be used for GPIO, fixed functions, or movable functions
 pub struct Pin<T: PinName, S: PinState> {
-    ty    : T,
-    _state: S,
+    ty   : T,
+    state: S,
 }
 
 impl<T> Pin<T, pin_state::Unknown> where T: PinName {
@@ -259,8 +259,8 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinName {
         self.ty.disable_fixed_functions(swm, fixed_functions);
 
         Pin {
-            ty    : self.ty,
-            _state: pin_state::Gpio(gpio),
+            ty   : self.ty,
+            state: pin_state::Gpio(gpio),
         }
     }
 }
@@ -271,21 +271,21 @@ impl<'gpio, T> Pin<T, pin_state::Gpio<'gpio>> where T: PinName {
     /// Disables the fixed function of the given pin (thus making it available
     /// for GPIO) and sets the GPIO direction to output.
     pub fn as_output(&mut self) {
-        self._state.0.gpio.dirset0.write(|w|
+        self.state.0.gpio.dirset0.write(|w|
             unsafe { w.dirsetp().bits(T::MASK) }
         )
     }
 
     /// Set pin output to HIGH
     pub fn set_high(&mut self) {
-        self._state.0.gpio.set0.write(|w|
+        self.state.0.gpio.set0.write(|w|
             unsafe { w.setp().bits(T::MASK) }
         )
     }
 
     /// Set pin output to LOW
     pub fn set_low(&mut self) {
-        self._state.0.gpio.clr0.write(|w|
+        self.state.0.gpio.clr0.write(|w|
             unsafe { w.clrp().bits(T::MASK) }
         );
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -175,17 +175,29 @@ pub struct Pin<'gpio, T: PinName> {
 
 impl<'gpio, T> Pin<'gpio, T> where T: PinName {
     /// Assign a movable function to the pin
+    ///
+    /// # Limitations
+    ///
+    /// This method can be used to assign a movable function to pins that are
+    /// currently used for something else. The HAL user needs to make sure that
+    /// this assignment doesn't conflict with any other uses of the pin.
     pub fn assign_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
         where F: MovableFunction
     {
-        function.assign::<T>(swm);
+        function.assign::<T>(&mut self._ty, swm);
     }
 
     /// Unassign a movable function from the pin
+    ///
+    /// # Limitations
+    ///
+    /// This method can be used to unassign a movable function from a pin, while
+    /// other parts of the code still rely on that function being assigned. The
+    /// HAL user is responsible for making sure this method is used correctly.
     pub fn unassign_function<F>(&mut self, function: &mut F, swm: &mut swm::Api)
         where F: MovableFunction
     {
-        function.unassign::<T>(swm);
+        function.unassign::<T>(&mut self._ty, swm);
     }
 
     /// Sets pin direction to output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,11 @@
 //! );
 //!
 //! let mut pio0_3 = gpio.pins().pio0_3
-//!     .as_gpio_pin(&mut peripherals.swm.fixed_functions, &mut swm);
+//!     .as_gpio_pin(
+//!         &gpio,
+//!         &mut peripherals.swm.fixed_functions,
+//!         &mut swm,
+//!     );
 //!
 //! // Set pin direction to output, so we can use it to blink an LED.
 //! pio0_3.as_output();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,8 @@
 //! let mut pio0_3 = gpio.pins().pio0_3;
 //!
 //! // Set pin direction to output, so we can use it to blink an LED.
-//! pio0_3.set_pin_to_output(&mut swm, &mut peripherals.swm.fixed_functions);
+//! pio0_3.as_gpio_pin(&mut peripherals.swm.fixed_functions, &mut swm);
+//! pio0_3.set_pin_to_output();
 //!
 //! // Let's already initialize the durations that we're going to sleep for
 //! // between changing the LED state. We do this by specifying the number of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,15 +155,14 @@
 //!     peripherals.syscon.ircout,
 //! );
 //!
+//! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
 //! let mut pio0_3 = gpio.pins().pio0_3
 //!     .as_gpio_pin(
 //!         &gpio,
 //!         &mut peripherals.swm.fixed_functions,
 //!         &mut swm,
-//!     );
-//!
-//! // Set pin direction to output, so we can use it to blink an LED.
-//! pio0_3.as_output();
+//!     )
+//!     .as_output();
 //!
 //! // Let's already initialize the durations that we're going to sleep for
 //! // between changing the LED state. We do this by specifying the number of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,11 +157,7 @@
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
 //! let mut pio0_3 = gpio.pins().pio0_3
-//!     .as_gpio_pin(
-//!         &gpio,
-//!         &mut peripherals.swm.fixed_functions,
-//!         &mut swm,
-//!     )
+//!     .as_gpio_pin(&gpio)
 //!     .as_output();
 //!
 //! // Let's already initialize the durations that we're going to sleep for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@
 //!
 //! // Set pin direction to output, so we can use it to blink an LED.
 //! pio0_3.as_gpio_pin(&mut peripherals.swm.fixed_functions, &mut swm);
-//! pio0_3.set_pin_to_output();
+//! pio0_3.as_output();
 //!
 //! // Let's already initialize the durations that we're going to sleep for
 //! // between changing the LED state. We do this by specifying the number of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,10 +155,10 @@
 //!     peripherals.syscon.ircout,
 //! );
 //!
-//! let mut pio0_3 = gpio.pins().pio0_3;
+//! let mut pio0_3 = gpio.pins().pio0_3
+//!     .as_gpio_pin(&mut peripherals.swm.fixed_functions, &mut swm);
 //!
 //! // Set pin direction to output, so we can use it to blink an LED.
-//! pio0_3.as_gpio_pin(&mut peripherals.swm.fixed_functions, &mut swm);
 //! pio0_3.as_output();
 //!
 //! // Let's already initialize the durations that we're going to sleep for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@
 //!
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing it will actually lead to compile-time errors.
-//! let mut gpio = peripherals.gpio.init(&mut syscon);
+//! let mut gpio = peripherals.gpio.handle.init(&mut syscon);
 //! let mut swm  = peripherals.swm.api.init(&mut syscon);
 //! let mut wkt  = peripherals.wkt.init(&mut syscon);
 //!
@@ -156,7 +156,7 @@
 //! );
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
-//! let mut pio0_3 = gpio.pins().pio0_3
+//! let mut pio0_3 = peripherals.gpio.pins.pio0_3
 //!     .as_gpio_pin(&gpio)
 //!     .as_output();
 //!
@@ -491,7 +491,7 @@ pub struct Peripherals<'system> {
     pub wwdt: &'system lpc82x::WWDT,
 
     /// General Purpose I/O (GPIO)
-    pub gpio: GPIO<'system, init_state::Unknown>,
+    pub gpio: GPIO<'system>,
 
     /// Power Management Unit (PMU)
     pub pmu: PMU<'system>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,12 @@
 //! );
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
-//! let mut pio0_3 = peripherals.gpio.pins.pio0_3
+//! let mut pio0_3 = peripherals.gpio.pins.pio0_3;
+//! pio0_3.disable_function(
+//!     &mut peripherals.swm.fixed_functions.swclk,
+//!     &mut swm,
+//! );
+//! let mut pio0_3 = pio0_3
 //!     .as_gpio_pin(&gpio)
 //!     .as_output();
 //!

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -88,22 +88,19 @@ impl<'swm> Api<'swm, init_state::Unknown> {
 pub trait MovableFunction {
     /// Assigns the movable function to a pin
     ///
-    /// # Limitations
+    /// This method is intended for internal use. Please use
+    /// [`Pin::assign_function`] instead.
     ///
-    /// This method can be used to assign the movable function to pins that are
-    /// currently used for something else. The HAL user needs to make sure that
-    /// this assignment doesn't conflict with any other uses of the pin.
-    fn assign<P: PinName>(&mut self, swm: &mut Api);
+    /// [`Pin::assign_function`]: ../gpio/struct.Pin.html#method.assign_function
+    fn assign<P: PinName>(&mut self, pin: &mut P, swm: &mut Api);
 
     /// Unassign the movable function
     ///
-    /// # Limitations
+    /// This method is intended for internal use. Please use
+    /// [`Pin::unassign_function`] instead.
     ///
-    /// This method can be used to unassign a movable function from a pin, while
-    /// that pin is being used by some other parts of the code. The HAL user
-    /// needs to make sure not to unassign any functions that other code relies
-    /// on.
-    fn unassign<P: PinName>(&mut self, swm: &mut Api);
+    /// [`Pin::unassign_function`]: ../gpio/struct.Pin.html#method.unassign_function
+    fn unassign<P: PinName>(&mut self, pin: &mut P, swm: &mut Api);
 }
 
 macro_rules! movable_functions {
@@ -137,7 +134,10 @@ macro_rules! movable_functions {
             pub struct $type<'swm>(&'swm $reg_type);
 
             impl<'swm> MovableFunction for $type<'swm> {
-                fn assign<P: PinName>(&mut self, _swm: &mut Api) {
+                fn assign<P: PinName>(&mut self,
+                    _pin: &mut P,
+                    _swm: &mut Api,
+                ) {
                     // We're not using the `_swm` argument, but we require it,
                     // because the SWM needs to be clocked for this to work.
 
@@ -146,7 +146,10 @@ macro_rules! movable_functions {
                     )
                 }
 
-                fn unassign<P: PinName>(&mut self, _swm: &mut Api) {
+                fn unassign<P: PinName>(&mut self,
+                    _pin: &mut P,
+                    _swm: &mut Api,
+                ) {
                     // We're not using the `_swm` argument, but we require it,
                     // because the SWM needs to be clocked for this to work.
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -20,7 +20,30 @@ use lpc82x::swm::{
     PINENABLE0,
 };
 
-use gpio::PinName;
+use gpio::{
+    PIO0_0,
+    PIO0_1,
+    PIO0_2,
+    PIO0_3,
+    PIO0_4,
+    PIO0_5,
+    PIO0_6,
+    PIO0_7,
+    PIO0_8,
+    PIO0_9,
+    PIO0_10,
+    PIO0_11,
+    PIO0_13,
+    PIO0_14,
+    PIO0_17,
+    PIO0_18,
+    PIO0_19,
+    PIO0_20,
+    PIO0_21,
+    PIO0_22,
+    PIO0_23,
+    PinName,
+};
 use init_state::{
     self,
     InitState,
@@ -216,21 +239,28 @@ movable_functions!(
 
 /// Implemented for types that represent fixed functions
 pub trait FixedFunction {
+    /// The pin that this fixed function can be enabled on
+    type Pin: PinName;
+
     /// Enable the fixed function
     ///
-    /// # Limitations
+    /// This method is intended for internal use. Please use
+    /// [`Pin::enable_function`] instead.
     ///
-    /// The fixed function can be enabled on a pin that is currently used for
-    /// something else. The HAL user needs to make sure that this assignment
-    /// doesn't conflict with any other uses of the pin.
-    fn enable(&mut self, swm: &mut Api);
+    /// [`Pin::enable_function`]: ../gpio/struct.Pin.html#method.enable_function
+    fn enable(&mut self, pin: &mut Self::Pin, swm: &mut Api);
 
     /// Disable the fixed function
-    fn disable(&mut self, swm: &mut Api);
+    ///
+    /// This method is intended for internal use. Please use
+    /// [`Pin::disable_function`] instead.
+    ///
+    /// [`Pin::disable_function`]: ../gpio/struct.Pin.html#method.disable_function
+    fn disable(&mut self, pin: &mut Self::Pin, swm: &mut Api);
 }
 
 macro_rules! fixed_functions {
-    ($($type:ident, $field:ident;)*) => {
+    ($($type:ident, $field:ident, $pin:ty;)*) => {
         // Provides access to all fixed functions
         #[allow(missing_docs)]
         pub struct FixedFunctions<'swm> {
@@ -252,11 +282,13 @@ macro_rules! fixed_functions {
             pub struct $type<'swm>(&'swm PINENABLE0);
 
             impl<'swm> FixedFunction for $type<'swm> {
-                fn enable(&mut self, swm: &mut Api) {
+                type Pin = $pin;
+
+                fn enable(&mut self, _pin: &mut Self::Pin, swm: &mut Api) {
                     swm.swm.pinenable0.modify(|_, w| w.$field().clear_bit());
                 }
 
-                fn disable(&mut self, swm: &mut Api) {
+                fn disable(&mut self, _pin: &mut Self::Pin, swm: &mut Api) {
                     swm.swm.pinenable0.modify(|_, w| w.$field().set_bit());
                 }
             }
@@ -265,29 +297,29 @@ macro_rules! fixed_functions {
 }
 
 fixed_functions!(
-    ACMP_I1 , acmp_i1;
-    ACMP_I2 , acmp_i2;
-    ACMP_I3 , acmp_i3;
-    ACMP_I4 , acmp_i4;
-    SWCLK   , swclk;
-    SWDIO   , swdio;
-    XTALIN  , xtalin;
-    XTALOUT , xtalout;
-    RESETN  , resetn;
-    CLKIN   , clkin;
-    VDDCMP  , vddcmp;
-    I2C0_SDA, i2c0_sda;
-    I2C0_SCL, i2c0_scl;
-    ADC_0   , adc_0;
-    ADC_1   , adc_1;
-    ADC_2   , adc_2;
-    ADC_3   , adc_3;
-    ADC_4   , adc_4;
-    ADC_5   , adc_5;
-    ADC_6   , adc_6;
-    ADC_7   , adc_7;
-    ADC_8   , adc_8;
-    ADC_9   , adc_9;
-    ADC_10  , adc_10;
-    ADC_11  , adc_11;
+    ACMP_I1 , acmp_i1 , PIO0_0;
+    ACMP_I2 , acmp_i2 , PIO0_1;
+    ACMP_I3 , acmp_i3 , PIO0_14;
+    ACMP_I4 , acmp_i4 , PIO0_23;
+    SWCLK   , swclk   , PIO0_3;
+    SWDIO   , swdio   , PIO0_2;
+    XTALIN  , xtalin  , PIO0_8;
+    XTALOUT , xtalout , PIO0_9;
+    RESETN  , resetn  , PIO0_5;
+    CLKIN   , clkin   , PIO0_1;
+    VDDCMP  , vddcmp  , PIO0_6;
+    I2C0_SDA, i2c0_sda, PIO0_11;
+    I2C0_SCL, i2c0_scl, PIO0_10;
+    ADC_0   , adc_0   , PIO0_7;
+    ADC_1   , adc_1   , PIO0_6;
+    ADC_2   , adc_2   , PIO0_14;
+    ADC_3   , adc_3   , PIO0_23;
+    ADC_4   , adc_4   , PIO0_22;
+    ADC_5   , adc_5   , PIO0_21;
+    ADC_6   , adc_6   , PIO0_20;
+    ADC_7   , adc_7   , PIO0_19;
+    ADC_8   , adc_8   , PIO0_18;
+    ADC_9   , adc_9   , PIO0_17;
+    ADC_10  , adc_10  , PIO0_13;
+    ADC_11  , adc_11  , PIO0_4;
 );

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -107,7 +107,11 @@ impl<'swm> Api<'swm, init_state::Unknown> {
 }
 
 
-/// Implemented for types that represent movable functions
+/// A movable function
+///
+/// This trait is implemented for all types that represent movable functions.
+/// The user should not need to implement this trait, nor use its methods
+/// directly. Any changes to this trait will not be considered breaking changes.
 pub trait MovableFunction {
     /// Assigns the movable function to a pin
     ///
@@ -237,7 +241,11 @@ movable_functions!(
 );
 
 
-/// Implemented for types that represent fixed functions
+/// A fixed function
+///
+/// This trait is implemented for all types that represent fixed functions. The
+/// user should not need to implement this trait, nor use its methods directly.
+/// Any changes to this trait will not be considered breaking changes.
 pub trait FixedFunction {
     /// The pin that this fixed function can be enabled on
     type Pin: PinName;

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -13,15 +13,15 @@ use lpc82x::{
 };
 use nb;
 
-use gpio::PinName;
+use gpio::{
+    Pin,
+    PinName,
+};
 use init_state::{
     self,
     InitState,
 };
-use swm::{
-    self,
-    MovableFunction,
-};
+use swm;
 use syscon::{
     self,
     UARTFRG,
@@ -91,6 +91,8 @@ impl<'usart, 'swm, UsartX> USART<'usart, UsartX, init_state::Unknown>
     pub fn init<Rx: PinName, Tx: PinName>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut syscon::Api,
+        rx       : &mut Pin<Rx>,
+        tx       : &mut Pin<Tx>,
         rxd      : &mut UsartX::Rx,
         txd      : &mut UsartX::Tx,
         swm      : &mut swm::Api,
@@ -100,8 +102,8 @@ impl<'usart, 'swm, UsartX> USART<'usart, UsartX, init_state::Unknown>
         syscon.enable_clock(&mut self.usart);
         syscon.clear_reset(&mut self.usart);
 
-        rxd.assign::<Rx>(swm);
-        txd.assign::<Tx>(swm);
+        rx.assign_function(rxd, swm);
+        tx.assign_function(txd, swm);
 
         self.usart.brg.write(|w| unsafe { w.brgval().bits(baud_rate.brgval) });
 

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -14,6 +14,7 @@ use lpc82x::{
 use nb;
 
 use gpio::{
+    pin_state,
     Pin,
     PinName,
 };
@@ -91,8 +92,8 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     pub fn init<Rx: PinName, Tx: PinName>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut syscon::Api,
-        rx       : &mut Pin<Rx>,
-        tx       : &mut Pin<Tx>,
+        rx       : &mut Pin<Rx, pin_state::Unknown>,
+        tx       : &mut Pin<Tx, pin_state::Unknown>,
         rxd      : &mut UsartX::Rx,
         txd      : &mut UsartX::Tx,
         swm      : &mut swm::Api,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -67,9 +67,9 @@ pub struct USART<
     _state: State,
 }
 
-impl<'usart, 'swm, UsartX> USART<'usart, UsartX, init_state::Unknown>
+impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     where
-        UsartX            : Peripheral<'swm>,
+        UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     pub(crate) fn new(usart: &'usart UsartX) -> Self {
@@ -168,7 +168,7 @@ impl<'usart, 'swm, UsartX> USART<'usart, UsartX, init_state::Unknown>
 
 impl<'usart, UsartX> USART<'usart, UsartX>
     where
-        UsartX            : for<'a> Peripheral<'a>,
+        UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     /// Enables the USART interrupts
@@ -211,7 +211,7 @@ impl<'usart, UsartX> USART<'usart, UsartX>
 
 impl<'usart, UsartX> Read<u8> for USART<'usart, UsartX>
     where
-        UsartX            : for<'a> Peripheral<'a>,
+        UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     type Error = Error;
@@ -256,7 +256,7 @@ impl<'usart, UsartX> Read<u8> for USART<'usart, UsartX>
 
 impl<'usart, UsartX> Write<u8> for USART<'usart, UsartX>
     where
-        UsartX            : for<'a> Peripheral<'a>,
+        UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     type Error = !;
@@ -284,7 +284,7 @@ impl<'usart, UsartX> Write<u8> for USART<'usart, UsartX>
 
 impl<'usart, UsartX> blocking::Write<u8> for USART<'usart, UsartX>
     where
-        UsartX            : for<'a> Peripheral<'a>,
+        UsartX            : Peripheral,
         for<'a> &'a UsartX: syscon::ClockControl + syscon::ResetControl,
 {
     type Error = !;
@@ -306,7 +306,7 @@ impl<'usart, UsartX> blocking::Write<u8> for USART<'usart, UsartX>
 /// the other traits required are implemented for `&Self`. This should be
 /// resolved once we pick up some changes to upstream dependencies that are
 /// currently coming down the pipe.
-pub trait Peripheral<'swm>:
+pub trait Peripheral:
     Deref<Target = lpc82x::usart0::RegisterBlock>
     where
         for<'a> &'a Self: syscon::ClockControl,
@@ -322,25 +322,25 @@ pub trait Peripheral<'swm>:
     type Tx: swm::MovableFunction;
 }
 
-impl<'swm> Peripheral<'swm> for lpc82x::USART0 {
+impl Peripheral for lpc82x::USART0 {
     const INTERRUPT: Interrupt = Interrupt::UART0;
 
-    type Rx = swm::U0_RXD<'swm>;
-    type Tx = swm::U0_TXD<'swm>;
+    type Rx = swm::U0_RXD;
+    type Tx = swm::U0_TXD;
 }
 
-impl<'swm> Peripheral<'swm> for lpc82x::USART1 {
+impl Peripheral for lpc82x::USART1 {
     const INTERRUPT: Interrupt = Interrupt::UART1;
 
-    type Rx = swm::U1_RXD<'swm>;
-    type Tx = swm::U1_TXD<'swm>;
+    type Rx = swm::U1_RXD;
+    type Tx = swm::U1_TXD;
 }
 
-impl<'swm> Peripheral<'swm> for lpc82x::USART2 {
+impl Peripheral for lpc82x::USART2 {
     const INTERRUPT: Interrupt = Interrupt::UART2;
 
-    type Rx = swm::U2_RXD<'swm>;
-    type Tx = swm::U2_TXD<'swm>;
+    type Rx = swm::U2_RXD;
+    type Tx = swm::U2_TXD;
 }
 
 


### PR DESCRIPTION
This pull request updates the pin API, making it safer to use by adding type state for GPIO, as well as laying groundwork for additional SWM-related safety improvements later.

This is another step towards fixing #2, but we're not quite there yet.