### PR TITLE
[WIP] Quick and dirty upgrade to latest upstream crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,10 @@ travis-ci   = { repository = "braun-robotics/rust-lpc82x-hal" }
 
 
 [dependencies]
-cortex-m     = "0.3.1"
+cortex-m     = "0.4"
 embedded-hal = "0.1"
-lpc82x       = "0.2"
+lpc82x       = { git = "https://github.com/hannobraun/rust-lpc82x.git", branch = "svd2rust-update" }
 nb           = "0.1.1"
-
-
-[patch.crates-io]
-# https://github.com/japaric/cortex-m/pull/63
-cortex-m = { git = "https://github.com/hannobraun/cortex-m.git", branch = "inline-asm" }
 
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,9 @@
 //! The following is an example of a simple application that blinks an LED.
 //!
 //! ``` no_run
+//! extern crate lpc82x;
+//! extern crate lpc82x_hal;
+//!
 //! use lpc82x_hal::Peripherals;
 //! use lpc82x_hal::clock::Ticks;
 //! use lpc82x_hal::gpio::PIO0_3;
@@ -135,7 +138,12 @@
 //!
 //! // Initialize the peripherals. This is unsafe, because we're only allowed to
 //! // create one instance on `Peripherals`.
-//! let mut peripherals = unsafe { Peripherals::new() };
+//! let mut peripherals = unsafe {
+//!     Peripherals::new(
+//!         lpc82x::CorePeripherals.take().unwrap(),
+//!         lpc82x::Peripherals.take().unwrap(),
+//!     )
+//! };
 //!
 //! // Let's save some peripherals in local variables for convenience. This one
 //! // here doesn't require initialization.
@@ -258,14 +266,10 @@ pub use lpc82x::{
     CPUID,
     DCB,
     DWT,
-    FPB,
-    FPU,
-    ITM,
     MPU,
     NVIC,
     SCB,
     SYST,
-    TPIU,
     Interrupt,
 };
 
@@ -532,44 +536,45 @@ impl<'system> Peripherals<'system> {
     /// of `Peripherals`. Usually this means you call this method once, at the
     /// beginning of your program. But technically, you can call it again to
     /// create another instance, if the previous one has been dropped.
-    pub unsafe fn new() -> Self {
-        let peripherals = lpc82x::Peripherals::all();
-
+    pub unsafe fn new(
+        core_peripherals: &'system lpc82x::CorePeripherals,
+        peripherals     : &'system lpc82x::Peripherals,
+    ) -> Self {
         Peripherals {
-            cpuid: peripherals.CPUID,
-            dcb  : peripherals.DCB,
-            dwt  : peripherals.DWT,
-            nvic : peripherals.NVIC,
-            scb  : peripherals.SCB,
-            syst : peripherals.SYST,
+            cpuid: &core_peripherals.CPUID,
+            dcb  : &core_peripherals.DCB,
+            dwt  : &core_peripherals.DWT,
+            nvic : &core_peripherals.NVIC,
+            scb  : &core_peripherals.SCB,
+            syst : &core_peripherals.SYST,
 
-            adc       : peripherals.ADC,
-            cmp       : peripherals.CMP,
-            crc       : peripherals.CRC,
-            dma       : peripherals.DMA,
-            dmatrigmux: peripherals.DMATRIGMUX,
-            flashctrl : peripherals.FLASHCTRL,
-            i2c0      : peripherals.I2C0,
-            i2c1      : peripherals.I2C1,
-            i2c2      : peripherals.I2C2,
-            i2c3      : peripherals.I2C3,
-            inputmux  : peripherals.INPUTMUX,
-            iocon     : peripherals.IOCON,
-            mrt       : peripherals.MRT,
-            pin_int   : peripherals.PIN_INT,
-            sct       : peripherals.SCT,
-            spi0      : peripherals.SPI0,
-            spi1      : peripherals.SPI1,
-            wwdt      : peripherals.WWDT,
+            adc       : &peripherals.ADC,
+            cmp       : &peripherals.CMP,
+            crc       : &peripherals.CRC,
+            dma       : &peripherals.DMA,
+            dmatrigmux: &peripherals.DMATRIGMUX,
+            flashctrl : &peripherals.FLASHCTRL,
+            i2c0      : &peripherals.I2C0,
+            i2c1      : &peripherals.I2C1,
+            i2c2      : &peripherals.I2C2,
+            i2c3      : &peripherals.I2C3,
+            inputmux  : &peripherals.INPUTMUX,
+            iocon     : &peripherals.IOCON,
+            mrt       : &peripherals.MRT,
+            pin_int   : &peripherals.PIN_INT,
+            sct       : &peripherals.SCT,
+            spi0      : &peripherals.SPI0,
+            spi1      : &peripherals.SPI1,
+            wwdt      : &peripherals.WWDT,
 
-            gpio  : GPIO::new(peripherals.GPIO_PORT),
-            pmu   : PMU::new(peripherals.PMU),
-            swm   : SWM::new(peripherals.SWM),
-            syscon: SYSCON::new(peripherals.SYSCON),
-            usart0: USART::new(peripherals.USART0),
-            usart1: USART::new(peripherals.USART1),
-            usart2: USART::new(peripherals.USART2),
-            wkt   : WKT::new(peripherals.WKT),
+            gpio  : GPIO::new(&peripherals.GPIO_PORT),
+            pmu   : PMU::new(&peripherals.PMU),
+            swm   : SWM::new(&peripherals.SWM),
+            syscon: SYSCON::new(&peripherals.SYSCON),
+            usart0: USART::new(&peripherals.USART0),
+            usart1: USART::new(&peripherals.USART1),
+            usart2: USART::new(&peripherals.USART2),
+            wkt   : WKT::new(&peripherals.WKT),
         }
     }
 }

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -99,7 +99,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [handle the WKT interrupt]: ../wkt/struct.WKT.html#method.handle_interrupt
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu, 'wkt> {
-    nvic: &'r lpc82x::NVIC,
+    nvic: &'r mut lpc82x::NVIC,
     pmu : &'pmu mut pmu::Api<'pmu>,
     scb : &'r lpc82x::SCB,
     wkt : &'wkt mut WKT<'wkt>,
@@ -108,7 +108,7 @@ pub struct Regular<'r, 'pmu, 'wkt> {
 impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
     /// Prepare regular sleep mode
     pub fn prepare(
-        nvic: &'r lpc82x::NVIC,
+        nvic: &'r mut lpc82x::NVIC,
         pmu : &'pmu mut pmu::Api<'pmu>,
         scb : &'r lpc82x::SCB,
         wkt : &'wkt mut WKT<'wkt>,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -159,7 +159,7 @@ impl<'usart, UsartX> USART<'usart, UsartX>
     /// Enables the interrupts for this USART peripheral. This only enables
     /// interrupts in general. It doesn't enable any specific interrupt. Other
     /// methods must be used for this.
-    pub fn enable_interrupts(&mut self, nvic: &NVIC) {
+    pub fn enable_interrupts(&mut self, nvic: &mut NVIC) {
         nvic.enable(UsartX::INTERRUPT);
     }
 

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -101,7 +101,7 @@ impl<'wkt> WKT<'wkt> {
     /// See [`handle_interrupt`] for details.
     ///
     /// [`handle_interrupt`]: #method.handle_interrupt
-    pub fn enable_interrupt(&mut self, nvic: &lpc82x::NVIC) {
+    pub fn enable_interrupt(&mut self, nvic: &mut lpc82x::NVIC) {
         nvic.enable(Interrupt::WKT);
     }
 
@@ -148,7 +148,11 @@ impl<'wkt> WKT<'wkt> {
 
             // Reset the alarm flag. Otherwise the interrupt will be triggered
             // over and over.
-            lpc82x::WKT.borrow(cs).ctrl.modify(|_, w| w.alarmflag().set_bit());
+            unsafe {
+                lpc82x::Peripherals::steal().WKT.ctrl.modify(|_, w|
+                    w.alarmflag().set_bit()
+                );
+            }
         });
     }
 }


### PR DESCRIPTION
This is a quick-and-dirty upgrade to the latest versions of the upstream crates. It depends on [this pull request for lpc82x](https://github.com/braun-robotics/rust-lpc82x/pull/36). This is just the fastest possible way I could make the changes work and not representative of what the real port will look like.

These changes are completely untested. Also, the example in the documentation no longer compiles for some reason. I have decided those are problems for another day (most likely the day I'm doing the port for real).

@Samonitari I hope this is enough to get you started with lpc82x-hal. Let me know if there's anything you need help with.