### PR TITLE
Update peripheral type names

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -227,7 +227,7 @@ impl<T> Pin<T, pin_state::Unused> where T: PinName {
     ///
     /// [`IOCON`]: ../../lpc82x/constant.IOCON.html
     /// [`ADC`]: ../../lpc82x/constant.ADC.html
-    pub fn as_adc_pin<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn as_adc_pin<F>(mut self, function: F, swm: &mut swm::Handle)
         -> (Pin<T, pin_state::Adc>, F::Enabled)
         where F: AdcFunction + FixedFunction<Pin=T> + fixed_function::Enable
     {
@@ -323,7 +323,10 @@ impl<'gpio, T> OutputPin for Pin<T, pin_state::Gpio<'gpio, direction::Output>>
 
 impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
     /// Enable the fixed function on this pin
-    pub fn enable_output_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn enable_output_function<F>(mut self,
+            function: F,
+            swm     : &mut swm::Handle,
+        )
         -> (Pin<T, pin_state::Swm<((),), Inputs>>, F::Enabled)
         where F: OutputFunction + FixedFunction<Pin=T> + fixed_function::Enable
     {
@@ -338,7 +341,10 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
     }
 
     /// Assign a movable function to the pin
-    pub fn assign_output_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn assign_output_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<((),), Inputs>>, F::Assigned)
         where F: OutputFunction + movable_function::Assign<T>
     {
@@ -355,7 +361,10 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
 
 impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinName {
     /// Disable the fixed function on this pin
-    pub fn disable_output_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn disable_output_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<(), Inputs>>, F::Disabled)
         where F: OutputFunction + FixedFunction<Pin=T> + fixed_function::Disable
     {
@@ -370,7 +379,10 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinName {
     }
 
     /// Unassign a movable function from the pin
-    pub fn unassign_output_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn unassign_output_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<(), Inputs>>, F::Unassigned)
         where F: OutputFunction + movable_function::Unassign<T>
     {
@@ -389,7 +401,10 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     where T: PinName
 {
     /// Enable the fixed function on this pin
-    pub fn enable_input_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn enable_input_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<Output, (Inputs,)>>, F::Enabled)
         where F: InputFunction + FixedFunction<Pin=T> + fixed_function::Enable
     {
@@ -404,7 +419,10 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     }
 
     /// Assign a movable function to the pin
-    pub fn assign_input_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn assign_input_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<Output, (Inputs,)>>, F::Assigned)
         where F: InputFunction + movable_function::Assign<T>
     {
@@ -423,7 +441,10 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     where T: PinName
 {
     /// Disable the fixed function on this pin
-    pub fn disable_input_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn disable_input_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<Output, Inputs>>, F::Disabled)
         where F: InputFunction + FixedFunction<Pin=T> + fixed_function::Disable
     {
@@ -438,7 +459,10 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     }
 
     /// Unassign a movable function from the pin
-    pub fn unassign_input_function<F>(mut self, function: F, swm: &mut swm::Api)
+    pub fn unassign_input_function<F>(mut self,
+        function: F,
+        swm     : &mut swm::Handle,
+    )
         -> (Pin<T, pin_state::Swm<Output, Inputs>>, F::Unassigned)
         where F: InputFunction + movable_function::Unassign<T>
     {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -62,7 +62,7 @@ pub struct Handle<'gpio, State: InitState = init_state::Initialized> {
 
 impl<'gpio> Handle<'gpio, init_state::Unknown> {
     /// Initialize GPIO
-    pub fn init(mut self, syscon: &mut syscon::Api)
+    pub fn init(mut self, syscon: &mut syscon::Handle)
         -> Handle<'gpio, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.gpio);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing it will actually lead to compile-time errors.
 //! let mut gpio = peripherals.gpio.handle.init(&mut syscon);
-//! let mut swm  = peripherals.swm.api.init(&mut syscon);
+//! let mut swm  = peripherals.swm.handle.init(&mut syscon);
 //! let mut wkt  = peripherals.wkt.init(&mut syscon);
 //!
 //! // We're going to need a clock for sleeping. Let's use the IRC-derived clock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
 //!
 //! // Let's save some peripherals in local variables for convenience. This one
 //! // here doesn't require initialization.
-//! let mut syscon = peripherals.syscon.api;
+//! let mut syscon = peripherals.syscon.handle;
 //!
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing it will actually lead to compile-time errors.

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -25,7 +25,7 @@ use clock::state::ClockState;
 /// [`lpc82x::PMU`]: ../../lpc82x/struct.PMU.html
 pub struct PMU<'pmu> {
     /// Main PMU API
-    pub api: Api<'pmu>,
+    pub handle: Handle<'pmu>,
 
     /// The 10 kHz low-power clock
     ///
@@ -36,7 +36,7 @@ pub struct PMU<'pmu> {
 impl<'pmu> PMU<'pmu> {
     pub(crate) fn new(pmu: &'pmu lpc82x::PMU) -> Self {
         PMU {
-            api: Api {
+            handle: Handle {
                 dpdctrl: &pmu.dpdctrl,
                 pcon   : &pmu.pcon,
             },
@@ -47,12 +47,12 @@ impl<'pmu> PMU<'pmu> {
 
 
 /// Main API of the PMU peripheral
-pub struct Api<'pmu> {
+pub struct Handle<'pmu> {
     dpdctrl: &'pmu DPDCTRL,
     pcon   : &'pmu PCON,
 }
 
-impl<'pmu> Api<'pmu> {
+impl<'pmu> Handle<'pmu> {
     /// Enter sleep mode
     ///
     /// The microcontroller will wake up from sleep mode, if an NVIC-enabled
@@ -103,7 +103,9 @@ impl LowPowerClock<clock::state::Disabled> {
     /// instance that implements [`clock::Enabled`].
     ///
     /// [`clock::Enabled`]: ../clock/trait.Enabled.html
-    pub fn enable(self, pmu: &mut Api) -> LowPowerClock<clock::state::Enabled> {
+    pub fn enable(self, pmu: &mut Handle)
+        -> LowPowerClock<clock::state::Enabled>
+    {
         pmu.dpdctrl.modify(|_, w|
             w.lposcen().enabled()
         );
@@ -119,7 +121,7 @@ impl LowPowerClock<clock::state::Enabled> {
     ///
     /// This method consumes an enabled instance of `LowPowerClock` and returns
     /// an instance that is disabled.
-    pub fn disable(self, pmu: &mut Api)
+    pub fn disable(self, pmu: &mut Handle)
         -> LowPowerClock<clock::state::Disabled>
     {
         pmu.dpdctrl.modify(|_, w|

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -100,7 +100,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu, 'wkt> {
     nvic: &'r lpc82x::NVIC,
-    pmu : &'pmu mut pmu::Api<'pmu>,
+    pmu : &'pmu mut pmu::Handle<'pmu>,
     scb : &'r lpc82x::SCB,
     wkt : &'wkt mut WKT<'wkt>,
 }
@@ -109,7 +109,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
     /// Prepare regular sleep mode
     pub fn prepare(
         nvic: &'r lpc82x::NVIC,
-        pmu : &'pmu mut pmu::Api<'pmu>,
+        pmu : &'pmu mut pmu::Handle<'pmu>,
         scb : &'r lpc82x::SCB,
         wkt : &'wkt mut WKT<'wkt>,
     )

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -83,7 +83,7 @@ impl<'swm> Handle<'swm, init_state::Unknown> {
     }
 
     /// Initialize the switch matrix
-    pub fn init(mut self, syscon: &mut syscon::Api)
+    pub fn init(mut self, syscon: &mut syscon::Handle)
         -> Handle<'swm, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.swm);

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -30,7 +30,7 @@ use clock::state::ClockState;
 /// [`lpc82x::SYSCON`]: ../../lpc82x/struct.SYSCON.html
 pub struct SYSCON<'syscon> {
     /// Main SYSCON API
-    pub api: Api<'syscon>,
+    pub handle: Handle<'syscon>,
 
     /// Brown-out detection
     pub bod: BOD,
@@ -71,7 +71,7 @@ pub struct SYSCON<'syscon> {
 impl<'syscon> SYSCON<'syscon> {
     pub(crate) fn new(syscon: &'syscon lpc82x::SYSCON) -> Self {
         SYSCON {
-            api: Api {
+            handle: Handle {
                 pdruncfg     : &syscon.pdruncfg,
                 presetctrl   : &syscon.presetctrl,
                 sysahbclkctrl: &syscon.sysahbclkctrl,
@@ -100,13 +100,13 @@ impl<'syscon> SYSCON<'syscon> {
 
 
 /// Main API of the SYSCON peripheral
-pub struct Api<'syscon> {
+pub struct Handle<'syscon> {
     pdruncfg     : &'syscon PDRUNCFG,
     presetctrl   : &'syscon PRESETCTRL,
     sysahbclkctrl: &'syscon SYSAHBCLKCTRL,
 }
 
-impl<'r> Api<'r> {
+impl<'r> Handle<'r> {
     /// Enable peripheral clock
     ///
     /// Enables the clock for a peripheral or other hardware component. HAL
@@ -447,7 +447,7 @@ impl IrcDerivedClock<clock::state::Disabled> {
     /// the IRC-derived clock again.
     ///
     /// [`clock::Enabled`]: ../clock/trait.Enabled.html
-    pub fn enable(self, syscon: &mut Api, mut irc: IRC, mut ircout: IRCOUT)
+    pub fn enable(self, syscon: &mut Handle, mut irc: IRC, mut ircout: IRCOUT)
         -> IrcDerivedClock<clock::state::Enabled>
     {
         syscon.power_up(&mut irc);

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -88,7 +88,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
         tx       : Pin<Tx, pin_state::Unused>,
         rxd      : UsartX::Rx,
         txd      : UsartX::Tx,
-        swm      : &mut swm::Api,
+        swm      : &mut swm::Handle,
     )
         -> nb::Result<USART<'usart, UsartX, init_state::Initialized>, !>
         where

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -83,7 +83,7 @@ impl<'usart, UsartX> USART<'usart, UsartX, init_state::Unknown>
     /// [`BaudRate`]: struct.BaudRate.html
     pub fn init<Rx: PinName, Tx: PinName>(mut self,
         baud_rate: &BaudRate,
-        syscon   : &mut syscon::Api,
+        syscon   : &mut syscon::Handle,
         rx       : Pin<Rx, pin_state::Unused>,
         tx       : Pin<Tx, pin_state::Unused>,
         rxd      : UsartX::Rx,

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -63,7 +63,7 @@ impl<'wkt> WKT<'wkt, init_state::Unknown> {
     }
 
     /// Initialize the self-wake-up timer
-    pub fn init(mut self, syscon: &mut syscon::Api)
+    pub fn init(mut self, syscon: &mut syscon::Handle)
         -> WKT<'wkt, init_state::Initialized>
     {
         syscon.enable_clock(&mut self.wkt);


### PR DESCRIPTION
Some peripherals consist of multiple types, one of which is the "main" type. So far, I've used various names for those, but I've decided on one now: `Handle`, as this main type can be seen as a handle to the peripheral where such a thing is required.