### PR TITLE
Fix sleep function triggering WKT handler

### DIFF
--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -249,7 +249,6 @@ impl<'r, 'pmu, 'wkt, Clock> Sleep<Clock> for Regular<'r, 'pmu, 'wkt>
         }
 
         self.wkt.select_clock::<Clock>();
-        self.nvic.enable(Interrupt::WKT);
         self.wkt.start(ticks.value);
 
         // Within the this closure, interrupts are enabled, but interrupt


### PR DESCRIPTION
The sleep function was triggering the WKT interrupt handler, which it
really shouldn't do. This mistake snuck in while I squashed some commits
in #61.