### PR TITLE
Fix build on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@
 
 #![feature(const_fn)]
 #![feature(const_refcell_new)]
-#![feature(macro_reexport)]
+#![feature(use_extern_macros)]
 #![feature(never_type)]
 
 #![deny(warnings)]
@@ -239,10 +239,15 @@ extern crate std;
 
 extern crate cortex_m;
 extern crate embedded_hal;
-#[cfg_attr(feature = "rt",
-    macro_reexport(default_handler, exception, interrupt))]
 extern crate lpc82x;
 extern crate nb;
+
+#[cfg(feature = "rt")]
+pub use lpc82x::{
+    default_handler,
+    exception,
+    interrupt,
+};
 
 
 pub mod clock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,8 @@
 
 #![feature(const_fn)]
 #![feature(const_refcell_new)]
-#![feature(use_extern_macros)]
 #![feature(never_type)]
+#![cfg_attr(feature = "rt", feature(use_extern_macros))]
 
 #![deny(warnings)]
 #![deny(missing_docs)]


### PR DESCRIPTION
This is a partial fix for #71. This pulll request fixes the problem as far as this crate is concerned, but when building with the `rt` feature, the lpc82x crate won't build for the same reason.