### PR TITLE
Take ownership of peripheral structs

### DIFF
--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -25,7 +25,7 @@ fn main() {
     let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
     let     swm    = SWM::new(&mut peripherals.SWM);
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    let     wkt    = WKT::new(&mut peripherals.WKT);
+    let     wkt    = WKT::new(peripherals.WKT);
 
     // Other peripherals need to be initialized. Trying to use the API before
     // initializing them will actually lead to compile-time errors.

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -23,7 +23,7 @@ fn main() {
 
     // Create the peripheral interfaces.
     let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    let     swm    = SWM::new(&mut peripherals.SWM);
+    let     swm    = SWM::new(peripherals.SWM);
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     let     wkt    = WKT::new(peripherals.WKT);
 

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut peripherals = raw::Peripherals::take().unwrap();
 
     // Create the peripheral interfaces.
-    let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     let     swm    = SWM::new(&mut peripherals.SWM);
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     let     wkt    = WKT::new(peripherals.WKT);

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     let     swm    = SWM::new(&mut peripherals.SWM);
     let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
-    let     usart0 = USART::new(&mut peripherals.USART0);
+    let     usart0 = USART::new(peripherals.USART0);
 
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -20,7 +20,7 @@ fn main() {
     let mut peripherals = raw::Peripherals::take().unwrap();
 
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    let     swm    = SWM::new(&mut peripherals.SWM);
+    let     swm    = SWM::new(peripherals.SWM);
     let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     let     usart0 = USART::new(peripherals.USART0);
 

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -21,7 +21,7 @@ fn main() {
 
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     let     swm    = SWM::new(&mut peripherals.SWM);
-    let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     let     usart0 = USART::new(peripherals.USART0);
 
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -22,7 +22,7 @@
 //!
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
-//! let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //!
 //! let gpio_handle = gpio.handle.enable(&mut syscon.handle);
@@ -48,7 +48,7 @@
 //!
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
-//! let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     swm    = SWM::new(&mut peripherals.SWM);
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //!
@@ -103,17 +103,17 @@ use self::pin_state::PinState;
 /// [`gpio::Handle`]: struct.Handle.html
 /// [`Pins`]: struct.Pins.html
 /// [module documentation]: index.html
-pub struct GPIO<'gpio> {
+pub struct GPIO {
     /// The handle to the GPIO peripheral
-    pub handle: Handle<'gpio, init_state::Unknown,>,
+    pub handle: Handle<init_state::Unknown,>,
 
     /// The pins that can be used for GPIO or other functions
     pub pins: Pins,
 }
 
-impl<'gpio> GPIO<'gpio> {
+impl GPIO {
     /// Create an instance of `GPIO`
-    pub fn new(gpio: &'gpio mut raw::GPIO_PORT) -> Self {
+    pub fn new(gpio: raw::GPIO_PORT) -> Self {
         GPIO {
             handle: Handle {
                 gpio  : gpio,
@@ -133,12 +133,12 @@ impl<'gpio> GPIO<'gpio> {
 /// Please refer to the [module documentation] for more information.
 ///
 /// [module documentation]: index.html
-pub struct Handle<'gpio, State: InitState = init_state::Enabled> {
-    gpio  : &'gpio mut raw::GPIO_PORT,
+pub struct Handle<State: InitState = init_state::Enabled> {
+    gpio  : raw::GPIO_PORT,
     _state: State,
 }
 
-impl<'gpio, State> Handle<'gpio, State> where State: init_state::NotEnabled {
+impl<'gpio, State> Handle<State> where State: init_state::NotEnabled {
     /// Enable the GPIO peripheral
     ///
     /// Enables the clock and clears the peripheral reset for the GPIO
@@ -152,11 +152,11 @@ impl<'gpio, State> Handle<'gpio, State> where State: init_state::NotEnabled {
     /// that has its `State` type parameter set to [`Enabled`].
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub fn enable(self, syscon: &mut syscon::Handle)
-        -> Handle<'gpio, init_state::Enabled>
+    pub fn enable(mut self, syscon: &mut syscon::Handle)
+        -> Handle<init_state::Enabled>
     {
-        syscon.enable_clock(self.gpio);
-        syscon.clear_reset(self.gpio);
+        syscon.enable_clock(&mut self.gpio);
+        syscon.clear_reset(&mut self.gpio);
 
         Handle {
             gpio  : self.gpio,
@@ -165,7 +165,7 @@ impl<'gpio, State> Handle<'gpio, State> where State: init_state::NotEnabled {
     }
 }
 
-impl<'gpio, State> Handle<'gpio, State> where State: init_state::NotDisabled {
+impl<State> Handle<State> where State: init_state::NotDisabled {
     /// Disable the GPIO peripheral
     ///
     /// This method is only available, if `gpio::Handle` is not already in the
@@ -176,10 +176,10 @@ impl<'gpio, State> Handle<'gpio, State> where State: init_state::NotDisabled {
     /// that has its `State` type parameter set to [`Disabled`].
     ///
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, syscon: &mut syscon::Handle)
-        -> Handle<'gpio, init_state::Disabled>
+    pub fn disable(mut self, syscon: &mut syscon::Handle)
+        -> Handle<init_state::Disabled>
     {
-        syscon.disable_clock(self.gpio);
+        syscon.disable_clock(&mut self.gpio);
 
         Handle {
             gpio  : self.gpio,
@@ -362,7 +362,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let gpio = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let gpio = GPIO::new(peripherals.GPIO_PORT);
 /// #
 /// use lpc82x_hal::gpio::{
 ///     PIO0_12,
@@ -395,7 +395,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(&mut peripherals.SWM);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
@@ -441,7 +441,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// // To use general-purpose I/O, we need to enable the GPIO peripheral. The
@@ -480,7 +480,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let gpio_handle = gpio.handle.enable(&mut syscon.handle);
@@ -524,7 +524,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let gpio = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let gpio = GPIO::new(peripherals.GPIO_PORT);
 /// #
 /// // Affirm that the pin is unused, then transition to the SWM state
 /// let pin = unsafe { gpio.pins.pio0_12.affirm_default_state() }
@@ -561,7 +561,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(&mut peripherals.SWM);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
@@ -618,7 +618,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(&mut peripherals.SWM);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
@@ -704,7 +704,7 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinName {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// # let mut swm    = SWM::new(&mut peripherals.SWM);
     /// #
@@ -771,7 +771,7 @@ impl<T> Pin<T, pin_state::Unused> where T: PinName {
     /// #
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
-    /// let gpio        = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// let gpio        = GPIO::new(peripherals.GPIO_PORT);
     /// let gpio_handle = gpio.handle.enable(&mut syscon.handle);
     ///
     /// let pin = unsafe { gpio.pins.pio0_12.affirm_default_state() }
@@ -782,8 +782,8 @@ impl<T> Pin<T, pin_state::Unused> where T: PinName {
     ///
     /// [State Management]: #state-management
     /// [`gpio::Handle`]: struct.Handle.html
-    pub fn into_gpio_pin<'gpio>(self, gpio: &'gpio Handle<'gpio>)
-        -> Pin<T, pin_state::Gpio<'gpio, direction::Unknown>>
+    pub fn into_gpio_pin(self, gpio: &Handle)
+        -> Pin<T, pin_state::Gpio<direction::Unknown>>
     {
         Pin {
             ty   : self.ty,
@@ -820,7 +820,7 @@ impl<T> Pin<T, pin_state::Unused> where T: PinName {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// let gpio = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// let gpio = GPIO::new(peripherals.GPIO_PORT);
     ///
     /// let pin = unsafe { gpio.pins.pio0_12.affirm_default_state() }
     ///     .into_swm_pin();
@@ -914,7 +914,7 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let gpio_handle = gpio.handle.enable(&mut syscon.handle);
@@ -1062,7 +1062,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1137,7 +1137,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1223,7 +1223,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinName {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1310,7 +1310,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinName {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1394,7 +1394,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1464,7 +1464,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1552,7 +1552,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
@@ -1639,7 +1639,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(&mut peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -49,7 +49,7 @@
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(&mut peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM);
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //!
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -396,7 +396,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(&mut peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -562,7 +562,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(&mut peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -619,7 +619,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(&mut peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM);
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -706,7 +706,7 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinName {
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    /// # let mut swm    = SWM::new(&mut peripherals.SWM);
+    /// # let mut swm    = SWM::new(peripherals.SWM);
     /// #
     /// # let swclk = unsafe {
     /// #     swm.fixed_functions.swclk.affirm_default_state()
@@ -1063,7 +1063,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1138,7 +1138,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinName {
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1224,7 +1224,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinName {
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1311,7 +1311,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinName {
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1395,7 +1395,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1465,7 +1465,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1553,7 +1553,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -1640,7 +1640,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(&mut peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
 //! // Create the peripheral interfaces.
-//! let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     swm    = SWM::new(&mut peripherals.SWM);
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //! let     wkt    = WKT::new(peripherals.WKT);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@
 //!
 //! // Create the peripheral interfaces.
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(&mut peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM);
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //! let     wkt    = WKT::new(peripherals.WKT);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@
 //! let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
 //! let     swm    = SWM::new(&mut peripherals.SWM);
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-//! let     wkt    = WKT::new(&mut peripherals.WKT);
+//! let     wkt    = WKT::new(peripherals.WKT);
 //!
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing them will actually lead to compile-time errors.

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -15,7 +15,7 @@
 //! let mut core_peripherals = lpc82x::CorePeripherals::take().unwrap();
 //! let mut peripherals      = lpc82x::Peripherals::take().unwrap();
 //!
-//! let mut pmu = PMU::new(&mut peripherals.PMU);
+//! let mut pmu = PMU::new(peripherals.PMU);
 //!
 //! // Enters sleep mode. Unless we set up some interrupts, we won't wake up
 //! // from this again.
@@ -47,17 +47,17 @@ use raw;
 /// [module documentation] for more information.
 ///
 /// [module documentation]: index.html
-pub struct PMU<'pmu> {
+pub struct PMU {
     /// The handle to the PMU peripheral
-    pub handle: Handle<'pmu>,
+    pub handle: Handle,
 
     /// The 10 kHz low-power clock
     pub low_power_clock: LowPowerClock<init_state::Unknown>,
 }
 
-impl<'pmu> PMU<'pmu> {
+impl PMU {
     /// Create an instance of `PMU`
-    pub fn new(pmu: &'pmu mut raw::PMU) -> Self {
+    pub fn new(pmu: raw::PMU) -> Self {
         PMU {
             handle: Handle {
                 pmu: pmu,
@@ -74,11 +74,11 @@ impl<'pmu> PMU<'pmu> {
 /// PMU.
 ///
 /// [module documentation]: index.html
-pub struct Handle<'pmu> {
-    pmu: &'pmu raw::PMU,
+pub struct Handle {
+    pmu: raw::PMU,
 }
 
-impl<'pmu> Handle<'pmu> {
+impl Handle {
     /// Enter sleep mode
     ///
     /// The microcontroller will wake up from sleep mode, if an NVIC-enabled

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -192,14 +192,14 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [WKT]: ../wkt/struct.WKT.html
 /// [handle the WKT interrupt]: ../wkt/struct.WKT.html#method.handle_interrupt
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
-pub struct Regular<'r, 'pmu, 'wkt> {
+pub struct Regular<'r, 'pmu> {
     nvic: &'r mut raw::NVIC,
     pmu : &'pmu mut pmu::Handle<'pmu>,
     scb : &'r mut raw::SCB,
-    wkt : &'wkt mut WKT,
+    wkt : &'r mut WKT,
 }
 
-impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
+impl<'r, 'pmu> Regular<'r, 'pmu> {
     /// Prepare regular sleep mode
     ///
     /// Returns an instance of `sleep::Regular`, which implements [`Sleep`] and
@@ -216,7 +216,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
         nvic: &'r mut raw::NVIC,
         pmu : &'pmu mut pmu::Handle<'pmu>,
         scb : &'r mut raw::SCB,
-        wkt : &'wkt mut WKT,
+        wkt : &'r mut WKT,
     )
         -> Self
     {
@@ -229,7 +229,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
     }
 }
 
-impl<'r, 'pmu, 'wkt, Clock> Sleep<Clock> for Regular<'r, 'pmu, 'wkt>
+impl<'r, 'pmu, Clock> Sleep<Clock> for Regular<'r, 'pmu>
     where Clock: clock::Enabled + wkt::Clock
 {
     fn sleep<'clock, T>(&mut self, ticks: T)

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -73,7 +73,7 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 /// let mut peripherals = lpc82x::Peripherals::take().unwrap();
 ///
 /// let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-/// let     wkt    = WKT::new(&mut peripherals.WKT);
+/// let     wkt    = WKT::new(peripherals.WKT);
 ///
 /// let mut wkt = wkt.enable(&mut syscon.handle);
 ///
@@ -93,7 +93,7 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 /// [WKT]: ../wkt/struct.WKT.html
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Busy<'wkt> {
-    wkt: &'wkt mut WKT<'wkt>,
+    wkt: &'wkt mut WKT,
 }
 
 impl<'wkt> Busy<'wkt> {
@@ -109,7 +109,7 @@ impl<'wkt> Busy<'wkt> {
     /// [`Sleep`]: trait.Sleep.html
     /// [`WKT`]: ../wkt/struct.WKT.html
     /// [`Sleep::sleep`]: trait.Sleep.html#tymethod.sleep
-    pub fn prepare(wkt: &'wkt mut WKT<'wkt>) -> Self {
+    pub fn prepare(wkt: &'wkt mut WKT) -> Self {
         Busy {
             wkt: wkt,
         }
@@ -165,7 +165,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 ///
 /// let mut pmu    = PMU::new(&mut peripherals.PMU);
 /// let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-/// let     wkt    = WKT::new(&mut peripherals.WKT);
+/// let     wkt    = WKT::new(peripherals.WKT);
 ///
 /// let mut wkt = wkt.enable(&mut syscon.handle);
 ///
@@ -196,7 +196,7 @@ pub struct Regular<'r, 'pmu, 'wkt> {
     nvic: &'r mut raw::NVIC,
     pmu : &'pmu mut pmu::Handle<'pmu>,
     scb : &'r mut raw::SCB,
-    wkt : &'wkt mut WKT<'wkt>,
+    wkt : &'wkt mut WKT,
 }
 
 impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
@@ -216,7 +216,7 @@ impl<'r, 'pmu, 'wkt> Regular<'r, 'pmu, 'wkt> {
         nvic: &'r mut raw::NVIC,
         pmu : &'pmu mut pmu::Handle<'pmu>,
         scb : &'r mut raw::SCB,
-        wkt : &'wkt mut WKT<'wkt>,
+        wkt : &'wkt mut WKT,
     )
         -> Self
     {

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -192,14 +192,14 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [WKT]: ../wkt/struct.WKT.html
 /// [handle the WKT interrupt]: ../wkt/struct.WKT.html#method.handle_interrupt
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
-pub struct Regular<'r, 'pmu> {
+pub struct Regular<'r> {
     nvic: &'r mut raw::NVIC,
-    pmu : &'pmu mut pmu::Handle,
+    pmu : &'r mut pmu::Handle,
     scb : &'r mut raw::SCB,
     wkt : &'r mut WKT,
 }
 
-impl<'r, 'pmu> Regular<'r, 'pmu> {
+impl<'r> Regular<'r> {
     /// Prepare regular sleep mode
     ///
     /// Returns an instance of `sleep::Regular`, which implements [`Sleep`] and
@@ -214,7 +214,7 @@ impl<'r, 'pmu> Regular<'r, 'pmu> {
     /// [`Sleep::sleep`]: trait.Sleep.html#tymethod.sleep
     pub fn prepare(
         nvic: &'r mut raw::NVIC,
-        pmu : &'pmu mut pmu::Handle,
+        pmu : &'r mut pmu::Handle,
         scb : &'r mut raw::SCB,
         wkt : &'r mut WKT,
     )
@@ -229,7 +229,7 @@ impl<'r, 'pmu> Regular<'r, 'pmu> {
     }
 }
 
-impl<'r, 'pmu, Clock> Sleep<Clock> for Regular<'r, 'pmu>
+impl<'r, Clock> Sleep<Clock> for Regular<'r>
     where Clock: clock::Enabled + wkt::Clock
 {
     fn sleep<'clock, T>(&mut self, ticks: T)

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -163,7 +163,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// let mut core_peripherals = lpc82x::CorePeripherals::take().unwrap();
 /// let mut peripherals      = lpc82x::Peripherals::take().unwrap();
 ///
-/// let mut pmu    = PMU::new(&mut peripherals.PMU);
+/// let mut pmu    = PMU::new(peripherals.PMU);
 /// let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// let     wkt    = WKT::new(peripherals.WKT);
 ///
@@ -194,7 +194,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// [`wkt::Clock`]: ../wkt/trait.Clock.html
 pub struct Regular<'r, 'pmu> {
     nvic: &'r mut raw::NVIC,
-    pmu : &'pmu mut pmu::Handle<'pmu>,
+    pmu : &'pmu mut pmu::Handle,
     scb : &'r mut raw::SCB,
     wkt : &'r mut WKT,
 }
@@ -214,7 +214,7 @@ impl<'r, 'pmu> Regular<'r, 'pmu> {
     /// [`Sleep::sleep`]: trait.Sleep.html#tymethod.sleep
     pub fn prepare(
         nvic: &'r mut raw::NVIC,
-        pmu : &'pmu mut pmu::Handle<'pmu>,
+        pmu : &'pmu mut pmu::Handle,
         scb : &'r mut raw::SCB,
         wkt : &'r mut WKT,
     )

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -40,9 +40,9 @@ use self::fixed_function::FixedFunction;
 
 
 /// Interface to the switch matrix (SWM)
-pub struct SWM<'swm> {
+pub struct SWM {
     /// Main SWM API
-    pub handle: Handle<'swm, init_state::Unknown>,
+    pub handle: Handle<init_state::Unknown>,
 
     /// Movable functions
     pub movable_functions: MovableFunctions,
@@ -51,9 +51,9 @@ pub struct SWM<'swm> {
     pub fixed_functions: FixedFunctions,
 }
 
-impl<'swm> SWM<'swm> {
+impl SWM {
     /// Create an instance of `SWM`
-    pub fn new(swm: &'swm mut raw::SWM) -> Self {
+    pub fn new(swm: raw::SWM) -> Self {
         SWM {
             handle           : Handle::new(swm),
             movable_functions: MovableFunctions::new(),
@@ -64,13 +64,13 @@ impl<'swm> SWM<'swm> {
 
 
 /// Main API of the SWM peripheral
-pub struct Handle<'swm, State: InitState = init_state::Enabled> {
-    swm   : &'swm mut raw::SWM,
+pub struct Handle<State: InitState = init_state::Enabled> {
+    swm   : raw::SWM,
     _state: State,
 }
 
-impl<'swm> Handle<'swm, init_state::Unknown> {
-    pub(crate) fn new(swm: &'swm mut raw::SWM) -> Self {
+impl Handle<init_state::Unknown> {
+    pub(crate) fn new(swm: raw::SWM) -> Self {
         Handle {
             swm   : swm,
             _state: init_state::Unknown,
@@ -78,7 +78,7 @@ impl<'swm> Handle<'swm, init_state::Unknown> {
     }
 }
 
-impl<'swm, State> Handle<'swm, State> where State: init_state::NotEnabled {
+impl<State> Handle<State> where State: init_state::NotEnabled {
     /// Enable the switch matrix
     ///
     /// This method is only available, if `swm::Handle` is not already in the
@@ -89,10 +89,10 @@ impl<'swm, State> Handle<'swm, State> where State: init_state::NotEnabled {
     /// that has its `State` type parameter set to [`Enabled`].
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub fn enable(self, syscon: &mut syscon::Handle)
-        -> Handle<'swm, init_state::Enabled>
+    pub fn enable(mut self, syscon: &mut syscon::Handle)
+        -> Handle<init_state::Enabled>
     {
-        syscon.enable_clock(self.swm);
+        syscon.enable_clock(&mut self.swm);
 
         Handle {
             swm   : self.swm,
@@ -101,7 +101,7 @@ impl<'swm, State> Handle<'swm, State> where State: init_state::NotEnabled {
     }
 }
 
-impl<'swm, State> Handle<'swm, State> where State: init_state::NotDisabled {
+impl<State> Handle<State> where State: init_state::NotDisabled {
     /// Disable the switch matrix
     ///
     /// This method is only available, if `swm::Handle` is not already in the
@@ -112,10 +112,10 @@ impl<'swm, State> Handle<'swm, State> where State: init_state::NotDisabled {
     /// that has its `State` type parameter set to [`Disabled`].
     ///
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, syscon: &mut syscon::Handle)
-        -> Handle<'swm, init_state::Disabled>
+    pub fn disable(mut self, syscon: &mut syscon::Handle)
+        -> Handle<init_state::Disabled>
     {
-        syscon.disable_clock(self.swm);
+        syscon.disable_clock(&mut self.swm);
 
         Handle {
             swm   : self.swm,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -24,7 +24,7 @@
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-//! let     swm    = SWM::new(&mut peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM);
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     usart0 = USART::new(peripherals.USART0);
 //!

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -25,7 +25,7 @@
 //!
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //! let     swm    = SWM::new(&mut peripherals.SWM);
-//! let     gpio   = GPIO::new(&mut peripherals.GPIO_PORT);
+//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     usart0 = USART::new(peripherals.USART0);
 //!
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -147,7 +147,7 @@ impl WKT<init_state::Enabled> {
     }
 }
 
-impl timer::CountDown for WKT {
+impl timer::CountDown for WKT<init_state::Enabled> {
     type Time = u32;
 
     fn start<T>(&mut self, timeout: T) where T: Into<Self::Time> {


### PR DESCRIPTION
Changes the peripheral APIs to take ownership of peripheral structs. The only exception to this is SYSCON, as the svd2rust-generated code doesn't allow us to take ownership of single registers, which is what SYSCON (in its current form) would require.