### PR TITLE
Merge infrastructure for fixed and movable functions

### DIFF
--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -61,7 +61,7 @@ fn main() -> ! {
 
     // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
     let (pio0_3, _) = pio0_3
-        .disable_output_function(swclk, &mut swm_handle);
+        .unassign_output_function(swclk, &mut swm_handle);
     let mut pio0_3 = pio0_3
         .into_unused_pin()
         .into_gpio_pin(&gpio_handle)

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -81,7 +81,6 @@ use init_state::{
 use raw;
 use swm::{
     self,
-    movable_function_state,
     AdcChannel,
     FixedFunction,
     FixedFunctionTrait,
@@ -1179,12 +1178,12 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn assign_output_function<F>(mut self,
-        function: swm::Function<F, movable_function_state::Unassigned>,
+        function: swm::Function<F, swm::state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<((),), Inputs>>,
-            swm::Function<F, movable_function_state::Assigned<T>>,
+            swm::Function<F, swm::state::Assigned<T>>,
         )
         where F: OutputFunction + FunctionTrait<T>
     {
@@ -1363,12 +1362,12 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn unassign_output_function<F>(mut self,
-        function: swm::Function<F, movable_function_state::Assigned<T>>,
+        function: swm::Function<F, swm::state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<(), Inputs>>,
-            swm::Function<F, movable_function_state::Unassigned>,
+            swm::Function<F, swm::state::Unassigned>,
         )
         where F: OutputFunction + FunctionTrait<T>
     {
@@ -1518,12 +1517,12 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn assign_input_function<F>(mut self,
-        function: swm::Function<F, movable_function_state::Unassigned>,
+        function: swm::Function<F, swm::state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
-            swm::Function<F, movable_function_state::Assigned<T>>,
+            swm::Function<F, swm::state::Assigned<T>>,
         )
         where F: InputFunction + FunctionTrait<T>
     {
@@ -1704,12 +1703,12 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// [`swm::InputFunction`]: ../swm/trait.InputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn unassign_input_function<F>(mut self,
-        function: swm::Function<F, movable_function_state::Assigned<T>>,
+        function: swm::Function<F, swm::state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, Inputs>>,
-            swm::Function<F, movable_function_state::Unassigned>,
+            swm::Function<F, swm::state::Unassigned>,
         )
         where F: InputFunction + FunctionTrait<T>
     {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1187,7 +1187,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
             Pin<T, pin_state::Swm<((),), Inputs>>,
             MovableFunction<F, movable_function_state::Assigned<T>>,
         )
-        where F: OutputFunction + MovableFunctionTrait
+        where F: OutputFunction + MovableFunctionTrait<T>
     {
         let function = function.assign(&mut self.ty, swm);
 
@@ -1371,7 +1371,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
             Pin<T, pin_state::Swm<(), Inputs>>,
             MovableFunction<F, movable_function_state::Unassigned>,
         )
-        where F: OutputFunction + MovableFunctionTrait
+        where F: OutputFunction + MovableFunctionTrait<T>
     {
         let function = function.unassign(&mut self.ty, swm);
 
@@ -1526,7 +1526,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
             MovableFunction<F, movable_function_state::Assigned<T>>,
         )
-        where F: InputFunction + MovableFunctionTrait
+        where F: InputFunction + MovableFunctionTrait<T>
     {
         let function = function.assign(&mut self.ty, swm);
 
@@ -1712,7 +1712,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
             Pin<T, pin_state::Swm<Output, Inputs>>,
             MovableFunction<F, movable_function_state::Unassigned>,
         )
-        where F: InputFunction + MovableFunctionTrait
+        where F: InputFunction + MovableFunctionTrait<T>
     {
         let function = function.unassign(&mut self.ty, swm);
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -85,9 +85,9 @@ use swm::{
     AdcChannel,
     FixedFunction,
     FixedFunctionTrait,
+    FunctionTrait,
     InputFunction,
     MovableFunction,
-    MovableFunctionTrait,
     OutputFunction,
 };
 use syscon;
@@ -1187,7 +1187,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
             Pin<T, pin_state::Swm<((),), Inputs>>,
             MovableFunction<F, movable_function_state::Assigned<T>>,
         )
-        where F: OutputFunction + MovableFunctionTrait<T>
+        where F: OutputFunction + FunctionTrait<T>
     {
         let function = function.assign(&mut self.ty, swm);
 
@@ -1371,7 +1371,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
             Pin<T, pin_state::Swm<(), Inputs>>,
             MovableFunction<F, movable_function_state::Unassigned>,
         )
-        where F: OutputFunction + MovableFunctionTrait<T>
+        where F: OutputFunction + FunctionTrait<T>
     {
         let function = function.unassign(&mut self.ty, swm);
 
@@ -1526,7 +1526,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
             MovableFunction<F, movable_function_state::Assigned<T>>,
         )
-        where F: InputFunction + MovableFunctionTrait<T>
+        where F: InputFunction + FunctionTrait<T>
     {
         let function = function.assign(&mut self.ty, swm);
 
@@ -1712,7 +1712,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
             Pin<T, pin_state::Swm<Output, Inputs>>,
             MovableFunction<F, movable_function_state::Unassigned>,
         )
-        where F: InputFunction + MovableFunctionTrait<T>
+        where F: InputFunction + FunctionTrait<T>
     {
         let function = function.unassign(&mut self.ty, swm);
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -59,7 +59,7 @@
 //! };
 //! let pio0_6 = unsafe { gpio.pins.pio0_6.affirm_default_state() }
 //!     .into_swm_pin()
-//!     .enable_input_function(vddcmp, &mut swm_handle);
+//!     .assign_input_function(vddcmp, &mut swm_handle);
 //! ```
 //!
 //! [`GPIO`]: struct.GPIO.html
@@ -583,7 +583,7 @@ pins!(
 ///     .into_swm_pin();
 ///
 /// // Enable this pin's fixed function, which is an output function.
-/// let (pin, xtalout) = pin.enable_output_function(xtalout, &mut swm_handle);
+/// let (pin, xtalout) = pin.assign_output_function(xtalout, &mut swm_handle);
 ///
 /// // Now we can assign various input functions in addition.
 /// let (pin, _) = pin.assign_input_function(u0_rxd, &mut swm_handle);
@@ -594,7 +594,7 @@ pins!(
 ///
 /// // Once we disabled the currently enabled output function, we can assign
 /// // another output function.
-/// let (pin, _) = pin.disable_output_function(xtalout, &mut swm_handle);
+/// let (pin, _) = pin.unassign_output_function(xtalout, &mut swm_handle);
 /// let (pin, _) = pin.assign_output_function(u0_txd, &mut swm_handle);
 /// ```
 ///
@@ -727,7 +727,7 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinTrait {
     /// // function enabled by default. If we want to use it for something else,
     /// // we need to transition it into the unused state before we can do so.
     /// let pio0_3 = pio0_3
-    ///     .disable_output_function(swclk, &mut swm_handle)
+    ///     .unassign_output_function(swclk, &mut swm_handle)
     ///     .0 // also returns output function; we're only interested in pin
     ///     .into_unused_pin();
     /// ```
@@ -1033,89 +1033,6 @@ impl<'gpio, T> StatefulOutputPin
 }
 
 impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
-    /// Enable the fixed output function on this pin
-    ///
-    /// This method is only available, if two conditions are met:
-    /// - The pin is in the SWM state. Use [`into_swm_pin`] to achieve this.
-    /// - No output function, either fixed or movable, is enabled on or assigned
-    ///   to this pin. Please refer to [`swm::OutputFunction`] to learn which
-    ///   fixed and movable functions are output functions.
-    ///
-    /// Unless both of these conditions are met, code trying to call this method
-    /// will not compile.
-    ///
-    /// Consumes the pin instance and an instance of the fixed function that is
-    /// associated with this pin, and returns a tuple containing
-    /// - a new pin instance, its type state indicating that an output function
-    ///   is enabled; and
-    /// - a new instance of the fixed function, its state indicating that it is
-    ///   enabled. Please refer to the [`swm`] module to learn more about fixed
-    ///   function states.
-    ///
-    /// Only the fixed function that is associated with this pin is accepted as
-    /// an argument. Since not every pin has a fixed function associated with
-    /// it, and since not all fixed functions are output functions, this means
-    /// that this method is not callable for every pin.
-    ///
-    /// # Example
-    ///
-    /// ``` no_run
-    /// # extern crate lpc82x;
-    /// # extern crate lpc82x_hal;
-    /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
-    /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
-    /// #
-    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(peripherals.SWM);
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    /// #
-    /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
-    /// #
-    /// // Get PIO0_9 ready for function assignment
-    /// let pio0_9 = unsafe { gpio.pins.pio0_9.affirm_default_state() }
-    ///     .into_swm_pin();
-    ///
-    /// // Get the fixed function on PIO0_9 ready to be enabled
-    /// let xtalout = unsafe {
-    ///     swm.fixed_functions.xtalout.affirm_default_state()
-    /// };
-    ///
-    /// // Enable the fixed function
-    /// let (pio0_9, xtalout) = pio0_9.enable_output_function(
-    ///     xtalout,
-    ///     &mut swm_handle,
-    /// );
-    /// ```
-    ///
-    /// [`into_swm_pin`]: #method.into_swm_pin
-    /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
-    /// [`swm`]: ../swm/index.html
-    pub fn enable_output_function<F>(mut self,
-            function: swm::Function<F, swm::state::Unassigned>,
-            swm     : &mut swm::Handle,
-        )
-        -> (
-            Pin<T, pin_state::Swm<((),), Inputs>>,
-            swm::Function<F, swm::state::Assigned<T>>,
-        )
-        where F: OutputFunction + swm::FunctionTrait<T>
-    {
-        let function = function.assign(&mut self.ty, swm);
-
-        let pin = Pin {
-            ty   : self.ty,
-            state: pin_state::Swm::new(),
-        };
-
-        (pin, function)
-    }
-
     /// Assign a movable output function to this pin
     ///
     /// This method is only available, if two conditions are met:
@@ -1196,99 +1113,6 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
 }
 
 impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
-    /// Disable the fixed output function on this pin
-    ///
-    /// This method is only available, if two conditions are met:
-    /// - The pin is in the SWM state. Use [`into_swm_pin`] to achieve this.
-    /// - An output function, either fixed or movable, is enabled on or assigned
-    ///   to this pin. Please refer to [`swm::OutputFunction`] to learn which
-    ///   fixed and movable functions are output functions.
-    ///
-    /// Unless both of these conditions are met, code trying to call this method
-    /// will not compile.
-    ///
-    /// Consumes the pin instance and an instance of the fixed function that is
-    /// associated with this pin, and returns a tuple containing
-    /// - a new pin instance, its type state indicating that no output function
-    ///   is enabled; and
-    /// - a new instance of the fixed function, its state indicating that it is
-    ///   disabled. Please refer to the [`swm`] module to learn more about fixed
-    ///   function states.
-    ///
-    /// Only the fixed function that is associated with this pin is accepted as
-    /// an argument, and only if its state indicates that is enabled. This means
-    /// that, even though this method is available if any output function is
-    /// enabled on this pin, it can only be called if this pin's specific fixed
-    /// output function is enabled. Since not every pin has a fixed function
-    /// associated with it, and since not all fixed functions are output
-    /// functions, this also means that this method is not callable for every
-    /// pin.
-    ///
-    /// # Example
-    ///
-    /// ``` no_run
-    /// # extern crate lpc82x;
-    /// # extern crate lpc82x_hal;
-    /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
-    /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
-    /// #
-    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(peripherals.SWM);
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    /// #
-    /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
-    /// #
-    /// // PIO0_3 has a fixed output function enabled by default. Its state will
-    /// // reflect that after the following method call.
-    /// let pio0_3 = unsafe {
-    ///     gpio.pins.pio0_3.affirm_default_state()
-    /// };
-    ///
-    /// // SWCLK is the output function that is enabled on PIO0_3 by default.
-    /// // Here too will this be be reflected in its state after the following
-    /// // method call.
-    /// let swclk = unsafe {
-    ///     swm.fixed_functions.swclk.affirm_default_state()
-    /// };
-    ///
-    /// // Disable the fixed function
-    /// let (pio0_3, swclk) = pio0_3.disable_output_function(
-    ///     swclk,
-    ///     &mut swm_handle,
-    /// );
-    ///
-    /// // Now both PIO0_3 and SWCLK are available again
-    /// ```
-    ///
-    /// [`into_swm_pin`]: #method.into_swm_pin
-    /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
-    /// [`swm`]: ../swm/index.html
-    pub fn disable_output_function<F>(mut self,
-        function: swm::Function<F, swm::state::Assigned<T>>,
-        swm     : &mut swm::Handle,
-    )
-        -> (
-            Pin<T, pin_state::Swm<(), Inputs>>,
-            swm::Function<F, swm::state::Unassigned>,
-        )
-        where F: OutputFunction + swm::FunctionTrait<T>
-    {
-        let function = function.unassign(&mut self.ty, swm);
-
-        let pin = Pin {
-            ty   : self.ty,
-            state: pin_state::Swm::new(),
-        };
-
-        (pin, function)
-    }
-
     /// Unassign a movable output function from this pin
     ///
     /// This method is only available, if two conditions are met:
@@ -1382,84 +1206,6 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
 impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     where T: PinTrait
 {
-    /// Enable the fixed input function on this pin
-    ///
-    /// This method is only available, if the pin is in the SWM state. Code
-    /// trying to call this method while this condition is not met, will not
-    /// compile. You can use [`into_swm_pin`] to put the pin into the SWM state.
-    ///
-    /// Consumes the pin instance and an instance of the fixed function that is
-    /// associated with this pin, and returns a tuple containing
-    /// - a new pin instance, its type state indicating that an additonal input
-    ///   function has been enabled; and
-    /// - a new instance of the fixed function, its state indicating that it is
-    ///   enabled. Please refer to the [`swm`] module to learn more about fixed
-    ///   function states.
-    ///
-    /// Only the fixed function that is associated with this pin is accepted as
-    /// an argument. Since not every pin has a fixed function associated with
-    /// it, and since not all fixed functions are input functions, this means
-    /// that this method is not callable for every pin.
-    ///
-    /// # Example
-    ///
-    /// ``` no_run
-    /// # extern crate lpc82x;
-    /// # extern crate lpc82x_hal;
-    /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
-    /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
-    /// #
-    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(peripherals.SWM);
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    /// #
-    /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
-    /// #
-    /// // Get PIO0_8 ready for function assignment
-    /// let pio0_8 = unsafe { gpio.pins.pio0_8.affirm_default_state() }
-    ///     .into_swm_pin();
-    ///
-    /// // Get the fixed function on PIO0_8 ready to be enabled
-    /// let xtalin = unsafe {
-    ///     swm.fixed_functions.xtalin.affirm_default_state()
-    /// };
-    ///
-    /// // Enable the fixed function
-    /// let (pio0_8, xtalin) = pio0_8.enable_input_function(
-    ///     xtalin,
-    ///     &mut swm_handle,
-    /// );
-    /// ```
-    ///
-    /// [`into_swm_pin`]: #method.into_swm_pin
-    /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
-    /// [`swm`]: ../swm/index.html
-    pub fn enable_input_function<F>(mut self,
-        function: swm::Function<F, swm::state::Unassigned>,
-        swm     : &mut swm::Handle,
-    )
-        -> (
-            Pin<T, pin_state::Swm<Output, (Inputs,)>>,
-            swm::Function<F, swm::state::Assigned<T>>,
-        )
-        where F: InputFunction + swm::FunctionTrait<T>
-    {
-        let function = function.assign(&mut self.ty, swm);
-
-        let pin = Pin {
-            ty   : self.ty,
-            state: pin_state::Swm::new(),
-        };
-
-        (pin, function)
-    }
-
     /// Assign a movable input function to this pin
     ///
     /// This method is only available, if the pin is in the SWM state. Code
@@ -1537,99 +1283,6 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
 impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     where T: PinTrait
 {
-    /// Disable the fixed input function on this pin
-    ///
-    /// This method is only available, if two conditions are met:
-    /// - The pin is in the SWM state. Use [`into_swm_pin`] to achieve this.
-    /// - At least one input function, either fixed or movable, is enabled on or
-    ///   assigned to this pin. Please refer to [`swm::OutputFunction`] to learn
-    ///   which fixed and movable functions are output functions.
-    ///
-    /// Unless both of these conditions are met, code trying to call this method
-    /// will not compile.
-    ///
-    /// Consumes the pin instance and an instance of the fixed function that is
-    /// associated with this pin, and returns a tuple containing
-    /// - a new pin instance, its type state indicating that one less input
-    ///   function is enabled; and
-    /// - a new instance of the fixed function, its state indicating that it is
-    ///   disabled. Please refer to the [`swm`] module to learn more about fixed
-    ///   function states.
-    ///
-    /// Only the fixed function that is associated with this pin is accepted as
-    /// an argument, and only if its state indicates that is enabled. This means
-    /// that, even though this method is available if any input functions are
-    /// enabled on this pin, it can only be called if this pin's specific fixed
-    /// input function is enabled. Since not every pin has a fixed function
-    /// associated with it, and since not all fixed functions are input
-    /// functions, this also means that this method is not callable for every
-    /// pin.
-    ///
-    /// # Example
-    ///
-    /// ``` no_run
-    /// # extern crate lpc82x;
-    /// # extern crate lpc82x_hal;
-    /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
-    /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
-    /// #
-    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(peripherals.SWM);
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    /// #
-    /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
-    /// #
-    /// // PIO0_5 has a fixed input function enabled by default. Its state will
-    /// // reflect that after the following method call.
-    /// let pio0_5 = unsafe {
-    ///     gpio.pins.pio0_5.affirm_default_state()
-    /// };
-    ///
-    /// // RESETN is the input function that is enabled on PIO0_5 by default.
-    /// // Here too, will this be be reflected in its state after the following
-    /// // method call.
-    /// let resetn = unsafe {
-    ///     swm.fixed_functions.resetn.affirm_default_state()
-    /// };
-    ///
-    /// // Disable the fixed function
-    /// let (pio0_5, resetn) = pio0_5.disable_input_function(
-    ///     resetn,
-    ///     &mut swm_handle,
-    /// );
-    ///
-    /// // Now both PIO0_5 and RESETN are available again
-    /// ```
-    ///
-    /// [`into_swm_pin`]: #method.into_swm_pin
-    /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
-    /// [`swm`]: ../swm/index.html
-    pub fn disable_input_function<F>(mut self,
-        function: swm::Function<F, swm::state::Assigned<T>>,
-        swm     : &mut swm::Handle,
-    )
-        -> (
-            Pin<T, pin_state::Swm<Output, Inputs>>,
-            swm::Function<F, swm::state::Unassigned>,
-        )
-        where F: InputFunction + swm::FunctionTrait<T>
-    {
-        let function = function.unassign(&mut self.ty, swm);
-
-        let pin = Pin {
-            ty   : self.ty,
-            state: pin_state::Swm::new(),
-        };
-
-        (pin, function)
-    }
-
     /// Unassign a movable input function from this pin
     ///
     /// This method is only available, if two conditions are met:

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -82,9 +82,6 @@ use raw;
 use swm::{
     self,
     AdcChannel,
-    FixedFunction,
-    FixedFunctionTrait,
-    FunctionTrait,
     InputFunction,
     OutputFunction,
 };
@@ -870,16 +867,16 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// [`lpc82x::IOCON`]: https://docs.rs/lpc82x/0.3.*/lpc82x/struct.IOCON.html
     /// [`lpc82x::ADC`]: https://docs.rs/lpc82x/0.3.*/lpc82x/struct.ADC.html
     pub fn into_adc_pin<F>(mut self,
-        function: FixedFunction<F, swm::state::Unassigned>,
+        function: swm::Function<F, swm::state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Adc>,
-            FixedFunction<F, swm::state::Assigned<T>>,
+            swm::Function<F, swm::state::Assigned<T>>,
         )
-        where F: AdcChannel + FixedFunctionTrait<Pin=T>
+        where F: AdcChannel + swm::FunctionTrait<T>
     {
-        let function = function.enable(&mut self.ty, swm);
+        let function = function.assign(&mut self.ty, swm);
 
         let pin = Pin {
             ty   : self.ty,
@@ -1100,16 +1097,16 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn enable_output_function<F>(mut self,
-            function: FixedFunction<F, swm::state::Unassigned>,
+            function: swm::Function<F, swm::state::Unassigned>,
             swm     : &mut swm::Handle,
         )
         -> (
             Pin<T, pin_state::Swm<((),), Inputs>>,
-            FixedFunction<F, swm::state::Assigned<T>>,
+            swm::Function<F, swm::state::Assigned<T>>,
         )
-        where F: OutputFunction + FixedFunctionTrait<Pin=T>
+        where F: OutputFunction + swm::FunctionTrait<T>
     {
-        let function = function.enable(&mut self.ty, swm);
+        let function = function.assign(&mut self.ty, swm);
 
         let pin = Pin {
             ty   : self.ty,
@@ -1185,7 +1182,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
             Pin<T, pin_state::Swm<((),), Inputs>>,
             swm::Function<F, swm::state::Assigned<T>>,
         )
-        where F: OutputFunction + FunctionTrait<T>
+        where F: OutputFunction + swm::FunctionTrait<T>
     {
         let function = function.assign(&mut self.ty, swm);
 
@@ -1273,16 +1270,16 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn disable_output_function<F>(mut self,
-        function: FixedFunction<F, swm::state::Assigned<T>>,
+        function: swm::Function<F, swm::state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<(), Inputs>>,
-            FixedFunction<F, swm::state::Unassigned>,
+            swm::Function<F, swm::state::Unassigned>,
         )
-        where F: OutputFunction + FixedFunctionTrait<Pin=T>
+        where F: OutputFunction + swm::FunctionTrait<T>
     {
-        let function = function.disable(&mut self.ty, swm);
+        let function = function.unassign(&mut self.ty, swm);
 
         let pin = Pin {
             ty   : self.ty,
@@ -1369,7 +1366,7 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
             Pin<T, pin_state::Swm<(), Inputs>>,
             swm::Function<F, swm::state::Unassigned>,
         )
-        where F: OutputFunction + FunctionTrait<T>
+        where F: OutputFunction + swm::FunctionTrait<T>
     {
         let function = function.unassign(&mut self.ty, swm);
 
@@ -1444,16 +1441,16 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn enable_input_function<F>(mut self,
-        function: FixedFunction<F, swm::state::Unassigned>,
+        function: swm::Function<F, swm::state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
-            FixedFunction<F, swm::state::Assigned<T>>,
+            swm::Function<F, swm::state::Assigned<T>>,
         )
-        where F: InputFunction + FixedFunctionTrait<Pin=T>
+        where F: InputFunction + swm::FunctionTrait<T>
     {
-        let function = function.enable(&mut self.ty, swm);
+        let function = function.assign(&mut self.ty, swm);
 
         let pin = Pin {
             ty   : self.ty,
@@ -1524,7 +1521,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
             swm::Function<F, swm::state::Assigned<T>>,
         )
-        where F: InputFunction + FunctionTrait<T>
+        where F: InputFunction + swm::FunctionTrait<T>
     {
         let function = function.assign(&mut self.ty, swm);
 
@@ -1614,16 +1611,16 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn disable_input_function<F>(mut self,
-        function: FixedFunction<F, swm::state::Assigned<T>>,
+        function: swm::Function<F, swm::state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, Inputs>>,
-            FixedFunction<F, swm::state::Unassigned>,
+            swm::Function<F, swm::state::Unassigned>,
         )
-        where F: InputFunction + FixedFunctionTrait<Pin=T>
+        where F: InputFunction + swm::FunctionTrait<T>
     {
-        let function = function.disable(&mut self.ty, swm);
+        let function = function.unassign(&mut self.ty, swm);
 
         let pin = Pin {
             ty   : self.ty,
@@ -1710,7 +1707,7 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
             Pin<T, pin_state::Swm<Output, Inputs>>,
             swm::Function<F, swm::state::Unassigned>,
         )
-        where F: InputFunction + FunctionTrait<T>
+        where F: InputFunction + swm::FunctionTrait<T>
     {
         let function = function.unassign(&mut self.ty, swm);
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -870,12 +870,12 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// [`lpc82x::IOCON`]: https://docs.rs/lpc82x/0.3.*/lpc82x/struct.IOCON.html
     /// [`lpc82x::ADC`]: https://docs.rs/lpc82x/0.3.*/lpc82x/struct.ADC.html
     pub fn into_adc_pin<F>(mut self,
-        function: FixedFunction<F, init_state::Disabled>,
+        function: FixedFunction<F, swm::state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Adc>,
-            FixedFunction<F, init_state::Enabled>,
+            FixedFunction<F, swm::state::Assigned<T>>,
         )
         where F: AdcChannel + FixedFunctionTrait<Pin=T>
     {
@@ -1100,12 +1100,12 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn enable_output_function<F>(mut self,
-            function: FixedFunction<F, init_state::Disabled>,
+            function: FixedFunction<F, swm::state::Unassigned>,
             swm     : &mut swm::Handle,
         )
         -> (
             Pin<T, pin_state::Swm<((),), Inputs>>,
-            FixedFunction<F, init_state::Enabled>,
+            FixedFunction<F, swm::state::Assigned<T>>,
         )
         where F: OutputFunction + FixedFunctionTrait<Pin=T>
     {
@@ -1273,12 +1273,12 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn disable_output_function<F>(mut self,
-        function: FixedFunction<F, init_state::Enabled>,
+        function: FixedFunction<F, swm::state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<(), Inputs>>,
-            FixedFunction<F, init_state::Disabled>,
+            FixedFunction<F, swm::state::Unassigned>,
         )
         where F: OutputFunction + FixedFunctionTrait<Pin=T>
     {
@@ -1444,12 +1444,12 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn enable_input_function<F>(mut self,
-        function: FixedFunction<F, init_state::Disabled>,
+        function: FixedFunction<F, swm::state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
-            FixedFunction<F, init_state::Enabled>,
+            FixedFunction<F, swm::state::Assigned<T>>,
         )
         where F: InputFunction + FixedFunctionTrait<Pin=T>
     {
@@ -1614,12 +1614,12 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn disable_input_function<F>(mut self,
-        function: FixedFunction<F, init_state::Enabled>,
+        function: FixedFunction<F, swm::state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, Inputs>>,
-            FixedFunction<F, init_state::Disabled>,
+            FixedFunction<F, swm::state::Unassigned>,
         )
         where F: InputFunction + FixedFunctionTrait<Pin=T>
     {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -87,7 +87,6 @@ use swm::{
     FixedFunctionTrait,
     FunctionTrait,
     InputFunction,
-    MovableFunction,
     OutputFunction,
 };
 use syscon;
@@ -1180,12 +1179,12 @@ impl<T, Inputs> Pin<T, pin_state::Swm<(), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn assign_output_function<F>(mut self,
-        function: MovableFunction<F, movable_function_state::Unassigned>,
+        function: swm::Function<F, movable_function_state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<((),), Inputs>>,
-            MovableFunction<F, movable_function_state::Assigned<T>>,
+            swm::Function<F, movable_function_state::Assigned<T>>,
         )
         where F: OutputFunction + FunctionTrait<T>
     {
@@ -1364,12 +1363,12 @@ impl<T, Inputs> Pin<T, pin_state::Swm<((),), Inputs>> where T: PinTrait {
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn unassign_output_function<F>(mut self,
-        function: MovableFunction<F, movable_function_state::Assigned<T>>,
+        function: swm::Function<F, movable_function_state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<(), Inputs>>,
-            MovableFunction<F, movable_function_state::Unassigned>,
+            swm::Function<F, movable_function_state::Unassigned>,
         )
         where F: OutputFunction + FunctionTrait<T>
     {
@@ -1519,12 +1518,12 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, Inputs>>
     /// [`swm::OutputFunction`]: ../swm/trait.OutputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn assign_input_function<F>(mut self,
-        function: MovableFunction<F, movable_function_state::Unassigned>,
+        function: swm::Function<F, movable_function_state::Unassigned>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, (Inputs,)>>,
-            MovableFunction<F, movable_function_state::Assigned<T>>,
+            swm::Function<F, movable_function_state::Assigned<T>>,
         )
         where F: InputFunction + FunctionTrait<T>
     {
@@ -1705,12 +1704,12 @@ impl<T, Output, Inputs> Pin<T, pin_state::Swm<Output, (Inputs,)>>
     /// [`swm::InputFunction`]: ../swm/trait.InputFunction.html
     /// [`swm`]: ../swm/index.html
     pub fn unassign_input_function<F>(mut self,
-        function: MovableFunction<F, movable_function_state::Assigned<T>>,
+        function: swm::Function<F, movable_function_state::Assigned<T>>,
         swm     : &mut swm::Handle,
     )
         -> (
             Pin<T, pin_state::Swm<Output, Inputs>>,
-            MovableFunction<F, movable_function_state::Unassigned>,
+            swm::Function<F, movable_function_state::Unassigned>,
         )
         where F: InputFunction + FunctionTrait<T>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,13 +305,7 @@ pub mod init_state {
     /// initialization states. This is done for the purpose of documentation.
     /// HAL users should never need to implement this trait, nor use it
     /// directly.
-    pub trait InitState {
-        /// Returns an instances of the init state
-        ///
-        /// This method is intended for internal use. Any changes to this method
-        /// won't be considered breaking changes.
-        fn new() -> Self;
-    }
+    pub trait InitState {}
 
 
     /// Indicates that the hardware's state is currently unknown
@@ -320,9 +314,7 @@ pub mod init_state {
     /// initialized, as we don't know what happened before that.
     pub struct Unknown;
 
-    impl InitState for Unknown {
-        fn new() -> Self { Unknown }
-    }
+    impl InitState for Unknown {}
 
 
     /// Indicates that the hardware component is enabled
@@ -331,17 +323,13 @@ pub mod init_state {
     /// used for its intended purpose.
     pub struct Enabled;
 
-    impl InitState for Enabled {
-        fn new() -> Self { Enabled }
-    }
+    impl InitState for Enabled {}
 
 
     /// Indicates that the hardware component is disabled
     pub struct Disabled;
 
-    impl InitState for Disabled {
-        fn new() -> Self { Disabled }
-    }
+    impl InitState for Disabled {}
 
 
     /// Marks a hardware component as not being enabled

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
 //! let (pio0_3, _) = pio0_3
-//!     .disable_output_function(swclk, &mut swm_handle);
+//!     .unassign_output_function(swclk, &mut swm_handle);
 //! let mut pio0_3 = pio0_3
 //!     .into_unused_pin()
 //!     .into_gpio_pin(&gpio_handle)

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -264,7 +264,6 @@ macro_rules! movable_functions {
         $(
             $field:ident,
             $type:ident,
-            $reg_type:ident,
             $reg_name:ident,
             $reg_field:ident;
         )*
@@ -319,54 +318,54 @@ macro_rules! movable_functions {
 }
 
 movable_functions!(
-    u0_txd       , U0_TXD       , PINASSIGN0 , pinassign0 , u0_txd_o;
-    u0_rxd       , U0_RXD       , PINASSIGN0 , pinassign0 , u0_rxd_i;
-    u0_rts       , U0_RTS       , PINASSIGN0 , pinassign0 , u0_rts_o;
-    u0_cts       , U0_CTS       , PINASSIGN0 , pinassign0 , u0_cts_i;
-    u0_sclk      , U0_SCLK      , PINASSIGN1 , pinassign1 , u0_sclk_io;
-    u1_txd       , U1_TXD       , PINASSIGN1 , pinassign1 , u1_txd_o;
-    u1_rxd       , U1_RXD       , PINASSIGN1 , pinassign1 , u1_rxd_i;
-    u1_rts       , U1_RTS       , PINASSIGN1 , pinassign1 , u1_rts_o;
-    u1_cts       , U1_CTS       , PINASSIGN2 , pinassign2 , u1_cts_i;
-    u1_sclk      , U1_SCLK      , PINASSIGN2 , pinassign2 , u1_sclk_io;
-    u2_txd       , U2_TXD       , PINASSIGN2 , pinassign2 , u2_txd_o;
-    u2_rxd       , U2_RXD       , PINASSIGN2 , pinassign2 , u2_rxd_i;
-    u2_rts       , U2_RTS       , PINASSIGN3 , pinassign3 , u2_rts_o;
-    u2_cts       , U2_CTS       , PINASSIGN3 , pinassign3 , u2_cts_i;
-    u2_sclk      , U2_SCLK      , PINASSIGN3 , pinassign3 , u2_sclk_io;
-    spi0_sck     , SPI0_SCK     , PINASSIGN3 , pinassign3 , spi0_sck_io;
-    spi0_mosi    , SPI0_MOSI    , PINASSIGN4 , pinassign4 , spi0_mosi_io;
-    spi0_miso    , SPI0_MISO    , PINASSIGN4 , pinassign4 , spi0_miso_io;
-    spi0_ssel0   , SPI0_SSEL0   , PINASSIGN4 , pinassign4 , spi0_ssel0_io;
-    spi0_ssel1   , SPI0_SSEL1   , PINASSIGN4 , pinassign4 , spi0_ssel1_io;
-    spi0_ssel2   , SPI0_SSEL2   , PINASSIGN5 , pinassign5 , spi0_ssel2_io;
-    spi0_ssel3   , SPI0_SSEL3   , PINASSIGN5 , pinassign5 , spi0_ssel3_io;
-    spi1_sck     , SPI1_SCK     , PINASSIGN5 , pinassign5 , spi1_sck_io;
-    spi1_mosi    , SPI1_MOSI    , PINASSIGN5 , pinassign5 , spi1_mosi_io;
-    spi1_miso    , SPI1_MISO    , PINASSIGN6 , pinassign6 , spi1_miso_io;
-    spi1_ssel0   , SPI1_SSEL0   , PINASSIGN6 , pinassign6 , spi1_ssel0_io;
-    spi1_ssel1   , SPI1_SSEL1   , PINASSIGN6 , pinassign6 , spi1_ssel1_io;
-    sct_pin0     , SCT_PIN0     , PINASSIGN6 , pinassign6 , sct_in0_i;
-    sct_pin1     , SCT_PIN1     , PINASSIGN7 , pinassign7 , sct_in1_i;
-    sct_pin2     , SCT_PIN2     , PINASSIGN7 , pinassign7 , sct_in2_i;
-    sct_pin3     , SCT_PIN3     , PINASSIGN7 , pinassign7 , sct_in3_i;
-    sct_out0     , SCT_OUT0     , PINASSIGN7 , pinassign7 , sct_out0_o;
-    sct_out1     , SCT_OUT1     , PINASSIGN8 , pinassign8 , sct_out1_o;
-    sct_out2     , SCT_OUT2     , PINASSIGN8 , pinassign8 , sct_out2_o;
-    sct_out3     , SCT_OUT3     , PINASSIGN8 , pinassign8 , sct_out3_o;
-    sct_out4     , SCT_OUT4     , PINASSIGN8 , pinassign8 , sct_out4_o;
-    sct_out5     , SCT_OUT5     , PINASSIGN9 , pinassign9 , sct_out5_o;
-    i2c1_sda     , I2C1_SDA     , PINASSIGN9 , pinassign9 , i2c1_sda_io;
-    i2c1_scl     , I2C1_SCL     , PINASSIGN9 , pinassign9 , i2c1_scl_io;
-    i2c2_sda     , I2C2_SDA     , PINASSIGN9 , pinassign9 , i2c2_sda_io;
-    i2c2_scl     , I2C2_SCL     , PINASSIGN10, pinassign10, i2c2_scl_io;
-    i2c3_sda     , I2C3_SDA     , PINASSIGN10, pinassign10, i2c3_sda_io;
-    i2c3_scl     , I2C3_SCL     , PINASSIGN10, pinassign10, i2c3_scl_io;
-    adc_pintrig0 , ADC_PINTRIG0 , PINASSIGN10, pinassign10, adc_pintrig0_i;
-    acd_pintrig1 , ADC_PINTRIG1 , PINASSIGN11, pinassign11, adc_pintrig1_i;
-    acmp_o       , ACMP_O       , PINASSIGN11, pinassign11, acmp_o_o;
-    clkout       , CLKOUT       , PINASSIGN11, pinassign11, clkout_o;
-    gpio_int_bmat, GPIO_INT_BMAT, PINASSIGN11, pinassign11, gpio_int_bmat_o;
+    u0_txd       , U0_TXD       , pinassign0 , u0_txd_o;
+    u0_rxd       , U0_RXD       , pinassign0 , u0_rxd_i;
+    u0_rts       , U0_RTS       , pinassign0 , u0_rts_o;
+    u0_cts       , U0_CTS       , pinassign0 , u0_cts_i;
+    u0_sclk      , U0_SCLK      , pinassign1 , u0_sclk_io;
+    u1_txd       , U1_TXD       , pinassign1 , u1_txd_o;
+    u1_rxd       , U1_RXD       , pinassign1 , u1_rxd_i;
+    u1_rts       , U1_RTS       , pinassign1 , u1_rts_o;
+    u1_cts       , U1_CTS       , pinassign2 , u1_cts_i;
+    u1_sclk      , U1_SCLK      , pinassign2 , u1_sclk_io;
+    u2_txd       , U2_TXD       , pinassign2 , u2_txd_o;
+    u2_rxd       , U2_RXD       , pinassign2 , u2_rxd_i;
+    u2_rts       , U2_RTS       , pinassign3 , u2_rts_o;
+    u2_cts       , U2_CTS       , pinassign3 , u2_cts_i;
+    u2_sclk      , U2_SCLK      , pinassign3 , u2_sclk_io;
+    spi0_sck     , SPI0_SCK     , pinassign3 , spi0_sck_io;
+    spi0_mosi    , SPI0_MOSI    , pinassign4 , spi0_mosi_io;
+    spi0_miso    , SPI0_MISO    , pinassign4 , spi0_miso_io;
+    spi0_ssel0   , SPI0_SSEL0   , pinassign4 , spi0_ssel0_io;
+    spi0_ssel1   , SPI0_SSEL1   , pinassign4 , spi0_ssel1_io;
+    spi0_ssel2   , SPI0_SSEL2   , pinassign5 , spi0_ssel2_io;
+    spi0_ssel3   , SPI0_SSEL3   , pinassign5 , spi0_ssel3_io;
+    spi1_sck     , SPI1_SCK     , pinassign5 , spi1_sck_io;
+    spi1_mosi    , SPI1_MOSI    , pinassign5 , spi1_mosi_io;
+    spi1_miso    , SPI1_MISO    , pinassign6 , spi1_miso_io;
+    spi1_ssel0   , SPI1_SSEL0   , pinassign6 , spi1_ssel0_io;
+    spi1_ssel1   , SPI1_SSEL1   , pinassign6 , spi1_ssel1_io;
+    sct_pin0     , SCT_PIN0     , pinassign6 , sct_in0_i;
+    sct_pin1     , SCT_PIN1     , pinassign7 , sct_in1_i;
+    sct_pin2     , SCT_PIN2     , pinassign7 , sct_in2_i;
+    sct_pin3     , SCT_PIN3     , pinassign7 , sct_in3_i;
+    sct_out0     , SCT_OUT0     , pinassign7 , sct_out0_o;
+    sct_out1     , SCT_OUT1     , pinassign8 , sct_out1_o;
+    sct_out2     , SCT_OUT2     , pinassign8 , sct_out2_o;
+    sct_out3     , SCT_OUT3     , pinassign8 , sct_out3_o;
+    sct_out4     , SCT_OUT4     , pinassign8 , sct_out4_o;
+    sct_out5     , SCT_OUT5     , pinassign9 , sct_out5_o;
+    i2c1_sda     , I2C1_SDA     , pinassign9 , i2c1_sda_io;
+    i2c1_scl     , I2C1_SCL     , pinassign9 , i2c1_scl_io;
+    i2c2_sda     , I2C2_SDA     , pinassign9 , i2c2_sda_io;
+    i2c2_scl     , I2C2_SCL     , pinassign10, i2c2_scl_io;
+    i2c3_sda     , I2C3_SDA     , pinassign10, i2c3_sda_io;
+    i2c3_scl     , I2C3_SCL     , pinassign10, i2c3_scl_io;
+    adc_pintrig0 , ADC_PINTRIG0 , pinassign10, adc_pintrig0_i;
+    acd_pintrig1 , ADC_PINTRIG1 , pinassign11, adc_pintrig1_i;
+    acmp_o       , ACMP_O       , pinassign11, acmp_o_o;
+    clkout       , CLKOUT       , pinassign11, clkout_o;
+    gpio_int_bmat, GPIO_INT_BMAT, pinassign11, gpio_int_bmat_o;
 );
 
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -682,7 +682,13 @@ pub mod state {
     /// This trait is implemented by types that indicate the state of a movable
     /// function. It exists only to document which types those are. The user
     /// should not need to implement this trait, nor use it directly.
-    pub trait State {}
+    pub trait State {
+        /// Returns an instance of the state
+        ///
+        /// This method is intended for internal use. Any changes to this method
+        /// won't be considered breaking changes.
+        fn new() -> Self;
+    }
 
 
     /// Indicates that the current state of the movable function is unknown
@@ -691,17 +697,23 @@ pub mod state {
     /// happened before that.
     pub struct Unknown;
 
-    impl State for Unknown {}
+    impl State for Unknown {
+        fn new() -> Self { Unknown }
+    }
 
 
     /// Indicates that the movable function is unassigned
     pub struct Unassigned;
 
-    impl State for Unassigned {}
+    impl State for Unassigned {
+        fn new() -> Self { Unassigned }
+    }
 
 
     /// Indicates that the movable function is assigned to a pin
     pub struct Assigned<Pin>(pub(crate) PhantomData<Pin>);
 
-    impl<Pin> State for Assigned<Pin> {}
+    impl<Pin> State for Assigned<Pin> {
+        fn new() -> Self { Assigned(PhantomData) }
+    }
 }

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -142,7 +142,6 @@ impl<T> MovableFunction<T, movable_function_state::Unknown> {
     /// calling this method.
     pub unsafe fn affirm_default_state(self)
         -> MovableFunction<T, movable_function_state::Unassigned>
-        where T: MovableFunctionTrait
     {
         MovableFunction {
             ty    : self.ty,

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -197,41 +197,6 @@ impl<T, P> Function<T, state::Assigned<P>> {
 }
 
 
-/// Contains types that indicate the state of a movable function
-pub mod state {
-    use core::marker::PhantomData;
-
-
-    /// Implemented by types that indicate the state of a movable function
-    ///
-    /// This trait is implemented by types that indicate the state of a movable
-    /// function. It exists only to document which types those are. The user
-    /// should not need to implement this trait, nor use it directly.
-    pub trait State {}
-
-
-    /// Indicates that the current state of the movable function is unknown
-    ///
-    /// This is the case after the HAL is initialized, as we can't know what
-    /// happened before that.
-    pub struct Unknown;
-
-    impl State for Unknown {}
-
-
-    /// Indicates that the movable function is unassigned
-    pub struct Unassigned;
-
-    impl State for Unassigned {}
-
-
-    /// Indicates that the movable function is assigned to a pin
-    pub struct Assigned<Pin>(pub(crate) PhantomData<Pin>);
-
-    impl<Pin> State for Assigned<Pin> {}
-}
-
-
 /// Implemented by all movable functions
 pub trait FunctionTrait<P: PinTrait> {
     /// Assigns the movable function to a pin
@@ -705,3 +670,38 @@ impl InputFunction for VDDCMP {}
 impl InputFunction for XTALIN {}
 impl InputFunction for RESETN {}
 impl InputFunction for CLKIN {}
+
+
+/// Contains types that indicate the state of a movable function
+pub mod state {
+    use core::marker::PhantomData;
+
+
+    /// Implemented by types that indicate the state of a movable function
+    ///
+    /// This trait is implemented by types that indicate the state of a movable
+    /// function. It exists only to document which types those are. The user
+    /// should not need to implement this trait, nor use it directly.
+    pub trait State {}
+
+
+    /// Indicates that the current state of the movable function is unknown
+    ///
+    /// This is the case after the HAL is initialized, as we can't know what
+    /// happened before that.
+    pub struct Unknown;
+
+    impl State for Unknown {}
+
+
+    /// Indicates that the movable function is unassigned
+    pub struct Unassigned;
+
+    impl State for Unassigned {}
+
+
+    /// Indicates that the movable function is assigned to a pin
+    pub struct Assigned<Pin>(pub(crate) PhantomData<Pin>);
+
+    impl<Pin> State for Assigned<Pin> {}
+}

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -366,7 +366,7 @@ pub struct FixedFunction<T, State> {
     _state: State,
 }
 
-impl<T> FixedFunction<T, init_state::Unknown> {
+impl<T> FixedFunction<T, init_state::Unknown> where T: FixedFunctionTrait {
     /// Affirm that the fixed function is in its default state
     ///
     /// By calling this method, the user promises that the fixed function is in
@@ -379,7 +379,6 @@ impl<T> FixedFunction<T, init_state::Unknown> {
     /// calling this method.
     pub unsafe fn affirm_default_state(self)
         -> FixedFunction<T, T::DefaultState>
-        where T: FixedFunctionTrait
     {
         FixedFunction {
             ty    : self.ty,
@@ -388,7 +387,7 @@ impl<T> FixedFunction<T, init_state::Unknown> {
     }
 }
 
-impl<T> FixedFunction<T, init_state::Disabled> {
+impl<T> FixedFunction<T, init_state::Disabled> where T: FixedFunctionTrait {
     /// Enable the fixed function
     ///
     /// This method is intended for internal use only. Please use
@@ -399,7 +398,6 @@ impl<T> FixedFunction<T, init_state::Disabled> {
     /// [`Pin::enable_output_function`]: ../gpio/struct.Pin.html#method.enable_output_function
     pub fn enable(mut self, pin: &mut T::Pin, swm: &mut Handle)
         -> FixedFunction<T, init_state::Enabled>
-        where T: FixedFunctionTrait
     {
         self.ty.enable(pin, swm);
 
@@ -410,7 +408,7 @@ impl<T> FixedFunction<T, init_state::Disabled> {
     }
 }
 
-impl<T> FixedFunction<T, init_state::Enabled> {
+impl<T> FixedFunction<T, init_state::Enabled> where T: FixedFunctionTrait {
     /// Disable the fixed function
     ///
     /// This method is intended for internal use only. Please use
@@ -421,7 +419,6 @@ impl<T> FixedFunction<T, init_state::Enabled> {
     /// [`Pin::disable_output_function`]: ../gpio/struct.Pin.html#method.disable_output_function
     pub fn disable(mut self, pin: &mut T::Pin, swm: &mut Handle)
         -> FixedFunction<T, init_state::Disabled>
-        where T: FixedFunctionTrait
     {
         self.ty.disable(pin, swm);
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -124,12 +124,12 @@ impl<State> Handle<State> where State: init_state::NotDisabled {
 
 
 /// A movable function that can be assigned to any pin
-pub struct MovableFunction<T, State> {
+pub struct Function<T, State> {
     ty    : T,
     _state: State,
 }
 
-impl<T> MovableFunction<T, movable_function_state::Unknown> {
+impl<T> Function<T, movable_function_state::Unknown> {
     /// Affirm that the movable function is in its default state
     ///
     /// By calling this method, the user promises that the movable function is
@@ -141,16 +141,16 @@ impl<T> MovableFunction<T, movable_function_state::Unknown> {
     /// function to its default state, as specified in the user manual, before
     /// calling this method.
     pub unsafe fn affirm_default_state(self)
-        -> MovableFunction<T, movable_function_state::Unassigned>
+        -> Function<T, movable_function_state::Unassigned>
     {
-        MovableFunction {
+        Function {
             ty    : self.ty,
             _state: movable_function_state::Unassigned,
         }
     }
 }
 
-impl<T> MovableFunction<T, movable_function_state::Unassigned> {
+impl<T> Function<T, movable_function_state::Unassigned> {
     /// Assign the movable function to a pin
     ///
     /// This method is intended for internal use only. Please use
@@ -160,21 +160,21 @@ impl<T> MovableFunction<T, movable_function_state::Unassigned> {
     /// [`Pin::assign_input_function`]: ../gpio/struct.Pin.html#method.assign_input_function
     /// [`Pin::assign_output_function`]: ../gpio/struct.Pin.html#method.assign_output_function
     pub fn assign<P>(mut self, pin: &mut P, swm: &mut Handle)
-        -> MovableFunction<T, movable_function_state::Assigned<P>>
+        -> Function<T, movable_function_state::Assigned<P>>
         where
             T: FunctionTrait<P>,
             P: PinTrait,
     {
         self.ty.assign(pin, swm);
 
-        MovableFunction {
+        Function {
             ty    : self.ty,
             _state: movable_function_state::Assigned(PhantomData),
         }
     }
 }
 
-impl<T, P> MovableFunction<T, movable_function_state::Assigned<P>> {
+impl<T, P> Function<T, movable_function_state::Assigned<P>> {
     /// Unassign the movable function
     ///
     /// This method is intended for internal use only. Please use
@@ -184,14 +184,14 @@ impl<T, P> MovableFunction<T, movable_function_state::Assigned<P>> {
     /// [`Pin::unassign_input_function`]: ../gpio/struct.Pin.html#method.unassign_input_function
     /// [`Pin::unassign_output_function`]: ../gpio/struct.Pin.html#method.unassign_input_function
     pub fn unassign(mut self, pin: &mut P, swm: &mut Handle)
-        -> MovableFunction<T, movable_function_state::Unassigned>
+        -> Function<T, movable_function_state::Unassigned>
         where
             T: FunctionTrait<P>,
             P: PinTrait,
     {
         self.ty.unassign(pin, swm);
 
-        MovableFunction {
+        Function {
             ty    : self.ty,
             _state: movable_function_state::Unassigned,
         }
@@ -274,7 +274,7 @@ macro_rules! movable_functions {
         /// [`SWM`]: struct.SWM.html
         #[allow(missing_docs)]
         pub struct MovableFunctions {
-            $(pub $field: MovableFunction<
+            $(pub $field: Function<
                 $type,
                 movable_function_state::Unknown,
             >,)*
@@ -283,7 +283,7 @@ macro_rules! movable_functions {
         impl MovableFunctions {
             fn new() -> Self {
                 MovableFunctions {
-                    $($field: MovableFunction {
+                    $($field: Function {
                         ty    : $type(()),
                         _state: movable_function_state::Unknown,
                     },)*

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -162,7 +162,7 @@ impl<T> MovableFunction<T, movable_function_state::Unassigned> {
     pub fn assign<P>(mut self, pin: &mut P, swm: &mut Handle)
         -> MovableFunction<T, movable_function_state::Assigned<P>>
         where
-            T: MovableFunctionTrait,
+            T: MovableFunctionTrait<P>,
             P: PinTrait,
     {
         self.ty.assign(pin, swm);
@@ -186,7 +186,7 @@ impl<T, P> MovableFunction<T, movable_function_state::Assigned<P>> {
     pub fn unassign(mut self, pin: &mut P, swm: &mut Handle)
         -> MovableFunction<T, movable_function_state::Unassigned>
         where
-            T: MovableFunctionTrait,
+            T: MovableFunctionTrait<P>,
             P: PinTrait,
     {
         self.ty.unassign(pin, swm);
@@ -235,7 +235,7 @@ pub mod movable_function_state {
 
 
 /// Implemented by all movable functions
-pub trait MovableFunctionTrait {
+pub trait MovableFunctionTrait<P: PinTrait> {
     /// Assigns the movable function to a pin
     ///
     /// This method is intended for internal use only. Please use
@@ -244,7 +244,7 @@ pub trait MovableFunctionTrait {
     ///
     /// [`Pin::assign_input_function`]: ../gpio/struct.Pin.html#method.assign_input_function
     /// [`Pin::assign_output_function`]: ../gpio/struct.Pin.html#method.assign_output_function
-    fn assign<P>(&mut self, pin: &mut P, swm: &mut Handle) where P: PinTrait;
+    fn assign(&mut self, pin: &mut P, swm: &mut Handle);
 
     /// Unassign the movable function
     ///
@@ -254,7 +254,7 @@ pub trait MovableFunctionTrait {
     ///
     /// [`Pin::unassign_input_function`]: ../gpio/struct.Pin.html#method.unassign_input_function
     /// [`Pin::unassign_output_function`]: ../gpio/struct.Pin.html#method.unassign_input_function
-    fn unassign<P>(&mut self, pin: &mut P, swm: &mut Handle);
+    fn unassign(&mut self, pin: &mut P, swm: &mut Handle);
 }
 
 
@@ -297,22 +297,54 @@ macro_rules! movable_functions {
             #[allow(non_camel_case_types)]
             pub struct $type(());
 
-            impl MovableFunctionTrait for $type {
-                fn assign<P>(&mut self, _pin: &mut P, swm : &mut Handle)
-                    where P: PinTrait
-                {
-                    swm.swm.$reg_name.modify(|_, w|
-                        unsafe { w.$reg_field().bits(P::ID) }
-                    );
-                }
-
-                fn unassign<P>(&mut self, _pin: &mut P, swm : &mut Handle) {
-                    swm.swm.$reg_name.modify(|_, w|
-                        unsafe { w.$reg_field().bits(0xff) }
-                    );
-                }
-            }
+            impl_function!($type, $reg_name, $reg_field, PIO0_0 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_1 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_2 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_3 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_4 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_5 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_6 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_7 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_8 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_9 );
+            impl_function!($type, $reg_name, $reg_field, PIO0_10);
+            impl_function!($type, $reg_name, $reg_field, PIO0_11);
+            impl_function!($type, $reg_name, $reg_field, PIO0_12);
+            impl_function!($type, $reg_name, $reg_field, PIO0_13);
+            impl_function!($type, $reg_name, $reg_field, PIO0_14);
+            impl_function!($type, $reg_name, $reg_field, PIO0_15);
+            impl_function!($type, $reg_name, $reg_field, PIO0_16);
+            impl_function!($type, $reg_name, $reg_field, PIO0_17);
+            impl_function!($type, $reg_name, $reg_field, PIO0_18);
+            impl_function!($type, $reg_name, $reg_field, PIO0_19);
+            impl_function!($type, $reg_name, $reg_field, PIO0_20);
+            impl_function!($type, $reg_name, $reg_field, PIO0_21);
+            impl_function!($type, $reg_name, $reg_field, PIO0_22);
+            impl_function!($type, $reg_name, $reg_field, PIO0_23);
+            impl_function!($type, $reg_name, $reg_field, PIO0_24);
+            impl_function!($type, $reg_name, $reg_field, PIO0_25);
+            impl_function!($type, $reg_name, $reg_field, PIO0_26);
+            impl_function!($type, $reg_name, $reg_field, PIO0_27);
+            impl_function!($type, $reg_name, $reg_field, PIO0_28);
         )*
+    }
+}
+
+macro_rules! impl_function {
+    ($type:ident, $reg_name:ident, $reg_field:ident, $pin:ident) => {
+        impl MovableFunctionTrait<::gpio::$pin> for $type {
+            fn assign(&mut self, _pin: &mut ::gpio::$pin, swm : &mut Handle) {
+                swm.swm.$reg_name.modify(|_, w|
+                    unsafe { w.$reg_field().bits(::gpio::$pin::ID) }
+                );
+            }
+
+            fn unassign(&mut self, _pin: &mut ::gpio::$pin, swm : &mut Handle) {
+                swm.swm.$reg_name.modify(|_, w|
+                    unsafe { w.$reg_field().bits(0xff) }
+                );
+            }
+        }
     }
 }
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -129,7 +129,7 @@ pub struct Function<T, State> {
     _state: State,
 }
 
-impl<T> Function<T, movable_function_state::Unknown> {
+impl<T> Function<T, state::Unknown> {
     /// Affirm that the movable function is in its default state
     ///
     /// By calling this method, the user promises that the movable function is
@@ -140,17 +140,15 @@ impl<T> Function<T, movable_function_state::Unknown> {
     /// the HAL API, then the user must use those means to return the movable
     /// function to its default state, as specified in the user manual, before
     /// calling this method.
-    pub unsafe fn affirm_default_state(self)
-        -> Function<T, movable_function_state::Unassigned>
-    {
+    pub unsafe fn affirm_default_state(self) -> Function<T, state::Unassigned> {
         Function {
             ty    : self.ty,
-            _state: movable_function_state::Unassigned,
+            _state: state::Unassigned,
         }
     }
 }
 
-impl<T> Function<T, movable_function_state::Unassigned> {
+impl<T> Function<T, state::Unassigned> {
     /// Assign the movable function to a pin
     ///
     /// This method is intended for internal use only. Please use
@@ -160,7 +158,7 @@ impl<T> Function<T, movable_function_state::Unassigned> {
     /// [`Pin::assign_input_function`]: ../gpio/struct.Pin.html#method.assign_input_function
     /// [`Pin::assign_output_function`]: ../gpio/struct.Pin.html#method.assign_output_function
     pub fn assign<P>(mut self, pin: &mut P, swm: &mut Handle)
-        -> Function<T, movable_function_state::Assigned<P>>
+        -> Function<T, state::Assigned<P>>
         where
             T: FunctionTrait<P>,
             P: PinTrait,
@@ -169,12 +167,12 @@ impl<T> Function<T, movable_function_state::Unassigned> {
 
         Function {
             ty    : self.ty,
-            _state: movable_function_state::Assigned(PhantomData),
+            _state: state::Assigned(PhantomData),
         }
     }
 }
 
-impl<T, P> Function<T, movable_function_state::Assigned<P>> {
+impl<T, P> Function<T, state::Assigned<P>> {
     /// Unassign the movable function
     ///
     /// This method is intended for internal use only. Please use
@@ -184,7 +182,7 @@ impl<T, P> Function<T, movable_function_state::Assigned<P>> {
     /// [`Pin::unassign_input_function`]: ../gpio/struct.Pin.html#method.unassign_input_function
     /// [`Pin::unassign_output_function`]: ../gpio/struct.Pin.html#method.unassign_input_function
     pub fn unassign(mut self, pin: &mut P, swm: &mut Handle)
-        -> Function<T, movable_function_state::Unassigned>
+        -> Function<T, state::Unassigned>
         where
             T: FunctionTrait<P>,
             P: PinTrait,
@@ -193,14 +191,14 @@ impl<T, P> Function<T, movable_function_state::Assigned<P>> {
 
         Function {
             ty    : self.ty,
-            _state: movable_function_state::Unassigned,
+            _state: state::Unassigned,
         }
     }
 }
 
 
 /// Contains types that indicate the state of a movable function
-pub mod movable_function_state {
+pub mod state {
     use core::marker::PhantomData;
 
 
@@ -274,10 +272,7 @@ macro_rules! movable_functions {
         /// [`SWM`]: struct.SWM.html
         #[allow(missing_docs)]
         pub struct MovableFunctions {
-            $(pub $field: Function<
-                $type,
-                movable_function_state::Unknown,
-            >,)*
+            $(pub $field: Function<$type, state::Unknown>,)*
         }
 
         impl MovableFunctions {
@@ -285,7 +280,7 @@ macro_rules! movable_functions {
                 MovableFunctions {
                     $($field: Function {
                         ty    : $type(()),
-                        _state: movable_function_state::Unknown,
+                        _state: state::Unknown,
                     },)*
                 }
             }

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -129,7 +129,7 @@ pub struct Function<T, State> {
     _state: State,
 }
 
-impl<T> Function<T, state::Unknown> {
+impl<T> Function<T, state::Unknown> where T: DefaultState {
     /// Affirm that the movable function is in its default state
     ///
     /// By calling this method, the user promises that the movable function is
@@ -140,10 +140,10 @@ impl<T> Function<T, state::Unknown> {
     /// the HAL API, then the user must use those means to return the movable
     /// function to its default state, as specified in the user manual, before
     /// calling this method.
-    pub unsafe fn affirm_default_state(self) -> Function<T, state::Unassigned> {
+    pub unsafe fn affirm_default_state(self) -> Function<T, T::DefaultState> {
         Function {
             ty    : self.ty,
-            _state: state::Unassigned,
+            _state: state::State::new(),
         }
     }
 }
@@ -263,6 +263,10 @@ macro_rules! movable_functions {
             /// Represents a movable function
             #[allow(non_camel_case_types)]
             pub struct $type(());
+
+            impl DefaultState for $type {
+                type DefaultState = state::Unassigned;
+            }
 
             impl_function!($type, $reg_name, $reg_field, PIO0_0 );
             impl_function!($type, $reg_name, $reg_field, PIO0_1 );

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -537,6 +537,17 @@ macro_rules! fixed_functions {
             #[allow(non_camel_case_types)]
             pub struct $type(());
 
+            impl FunctionTrait<::gpio::$pin> for $type {
+                fn assign(&mut self, _: &mut ::gpio::$pin, swm : &mut Handle) {
+                    swm.swm.pinenable0.modify(|_, w| w.$field().clear_bit());
+                }
+
+                fn unassign(&mut self, _: &mut ::gpio::$pin, swm : &mut Handle)
+                {
+                    swm.swm.pinenable0.modify(|_, w| w.$field().set_bit());
+                }
+            }
+
             impl FixedFunctionTrait for $type {
                 type Pin = $pin;
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -509,7 +509,7 @@ pub trait FixedFunctionTrait {
 
 
 macro_rules! fixed_functions {
-    ($($type:ident, $field:ident, $pin:ty, $default_state:ident;)*) => {
+    ($($type:ident, $field:ident, $pin:ident, $default_state:ident;)*) => {
         /// Provides access to all fixed functions
         ///
         /// This struct is part of [`SWM`].

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -162,7 +162,7 @@ impl<T> MovableFunction<T, movable_function_state::Unassigned> {
     pub fn assign<P>(mut self, pin: &mut P, swm: &mut Handle)
         -> MovableFunction<T, movable_function_state::Assigned<P>>
         where
-            T: MovableFunctionTrait<P>,
+            T: FunctionTrait<P>,
             P: PinTrait,
     {
         self.ty.assign(pin, swm);
@@ -186,7 +186,7 @@ impl<T, P> MovableFunction<T, movable_function_state::Assigned<P>> {
     pub fn unassign(mut self, pin: &mut P, swm: &mut Handle)
         -> MovableFunction<T, movable_function_state::Unassigned>
         where
-            T: MovableFunctionTrait<P>,
+            T: FunctionTrait<P>,
             P: PinTrait,
     {
         self.ty.unassign(pin, swm);
@@ -235,7 +235,7 @@ pub mod movable_function_state {
 
 
 /// Implemented by all movable functions
-pub trait MovableFunctionTrait<P: PinTrait> {
+pub trait FunctionTrait<P: PinTrait> {
     /// Assigns the movable function to a pin
     ///
     /// This method is intended for internal use only. Please use
@@ -332,7 +332,7 @@ macro_rules! movable_functions {
 
 macro_rules! impl_function {
     ($type:ident, $reg_name:ident, $reg_field:ident, $pin:ident) => {
-        impl MovableFunctionTrait<::gpio::$pin> for $type {
+        impl FunctionTrait<::gpio::$pin> for $type {
             fn assign(&mut self, _pin: &mut ::gpio::$pin, swm : &mut Handle) {
                 swm.swm.$reg_name.modify(|_, w|
                     unsafe { w.$reg_field().bits(::gpio::$pin::ID) }

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -123,9 +123,9 @@ use raw::{
 };
 use swm::{
     self,
+    FunctionTrait,
     InputFunction,
     MovableFunction,
-    MovableFunctionTrait,
     OutputFunction,
 };
 use swm::movable_function_state::Assigned;
@@ -192,8 +192,8 @@ impl<UsartX, State> USART<UsartX, State>
     )
         -> nb::Result<USART<UsartX, init_state::Enabled>, !>
         where
-            UsartX::Rx: MovableFunctionTrait<Rx> + InputFunction,
-            UsartX::Tx: MovableFunctionTrait<Tx> + OutputFunction,
+            UsartX::Rx: FunctionTrait<Rx> + InputFunction,
+            UsartX::Tx: FunctionTrait<Tx> + OutputFunction,
     {
         syscon.enable_clock(&mut self.usart);
         syscon.clear_reset(&mut self.usart);

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -127,7 +127,6 @@ use swm::{
     InputFunction,
     OutputFunction,
 };
-use swm::movable_function_state::Assigned;
 use syscon::{
     self,
     UARTFRG,
@@ -186,8 +185,8 @@ impl<UsartX, State> USART<UsartX, State>
     pub fn enable<Rx: PinTrait, Tx: PinTrait>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut syscon::Handle,
-        _        : swm::Function<UsartX::Rx, Assigned<Rx>>,
-        _        : swm::Function<UsartX::Tx, Assigned<Tx>>,
+        _        : swm::Function<UsartX::Rx, swm::state::Assigned<Rx>>,
+        _        : swm::Function<UsartX::Tx, swm::state::Assigned<Tx>>,
     )
         -> nb::Result<USART<UsartX, init_state::Enabled>, !>
         where

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -125,7 +125,6 @@ use swm::{
     self,
     FunctionTrait,
     InputFunction,
-    MovableFunction,
     OutputFunction,
 };
 use swm::movable_function_state::Assigned;
@@ -187,8 +186,8 @@ impl<UsartX, State> USART<UsartX, State>
     pub fn enable<Rx: PinTrait, Tx: PinTrait>(mut self,
         baud_rate: &BaudRate,
         syscon   : &mut syscon::Handle,
-        _        : MovableFunction<UsartX::Rx, Assigned<Rx>>,
-        _        : MovableFunction<UsartX::Tx, Assigned<Tx>>,
+        _        : swm::Function<UsartX::Rx, Assigned<Rx>>,
+        _        : swm::Function<UsartX::Tx, Assigned<Tx>>,
     )
         -> nb::Result<USART<UsartX, init_state::Enabled>, !>
         where

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -192,8 +192,8 @@ impl<UsartX, State> USART<UsartX, State>
     )
         -> nb::Result<USART<UsartX, init_state::Enabled>, !>
         where
-            UsartX::Rx: MovableFunctionTrait + InputFunction,
-            UsartX::Tx: MovableFunctionTrait + OutputFunction,
+            UsartX::Rx: MovableFunctionTrait<Rx> + InputFunction,
+            UsartX::Tx: MovableFunctionTrait<Tx> + OutputFunction,
     {
         syscon.enable_clock(&mut self.usart);
         syscon.clear_reset(&mut self.usart);


### PR DESCRIPTION
This is a huge step towards reaching the goals laid out in #76. There's only one struct and one trait for SWM functions now. Many of the SWM-related methods in the pin API have been removed.