### PR TITLE
Simplify state management

### DIFF
--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -11,13 +11,7 @@ extern crate panic_abort;
 use cortex_m_rt::ExceptionFrame;
 
 use lpc82x_hal::prelude::*;
-use lpc82x_hal::{
-    raw,
-    GPIO,
-    SWM,
-    SYSCON,
-    WKT,
-};
+use lpc82x_hal::Peripherals;
 use lpc82x_hal::clock::Ticks;
 use lpc82x_hal::sleep;
 
@@ -27,20 +21,15 @@ entry!(main);
 fn main() -> ! {
     // Create the struct we're going to use to access all the peripherals. This
     // is unsafe, because we're only allowed to create one instance.
-    let peripherals = raw::Peripherals::take().unwrap();
-
-    // Create the peripheral interfaces.
-    let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    let     swm    = SWM::new(peripherals.SWM).split();
-    let mut syscon = SYSCON::new(peripherals.SYSCON);
-    let     wkt    = WKT::new(peripherals.WKT);
+    let mut p = Peripherals::take().unwrap();
 
     // Other peripherals need to be initialized. Trying to use the API before
     // initializing them will actually lead to compile-time errors.
-    let mut syscon     = syscon.split();
-    let     gpio       = gpio.enable(&mut syscon.handle);
+    let     swm        = p.swm.split();
+    let mut syscon     = p.syscon.split();
+    let     gpio       = p.gpio.enable(&mut syscon.handle);
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
-    let mut wkt        = wkt.enable(&mut syscon.handle);
+    let mut wkt        = p.wkt.enable(&mut syscon.handle);
 
     // We're going to need a clock for sleeping. Let's use the IRC-derived clock
     // that runs at 750 kHz.

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -25,11 +25,9 @@ fn main() -> ! {
 
     // Other peripherals need to be initialized. Trying to use the API before
     // initializing them will actually lead to compile-time errors.
-    let     swm        = p.swm.split();
-    let mut syscon     = p.syscon.split();
-    let     gpio       = p.gpio.enable(&mut syscon.handle);
-    let mut swm_handle = swm.handle.enable(&mut syscon.handle);
-    let mut wkt        = p.wkt.enable(&mut syscon.handle);
+    let mut swm    = p.swm.split();
+    let mut syscon = p.syscon.split();
+    let mut wkt    = p.wkt.enable(&mut syscon.handle);
 
     // We're going to need a clock for sleeping. Let's use the IRC-derived clock
     // that runs at 750 kHz.
@@ -51,10 +49,10 @@ fn main() -> ! {
 
     // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
     let (_, pio0_3) = swclk
-        .unassign(pio0_3, &mut swm_handle);
+        .unassign(pio0_3, &mut swm.handle);
     let mut pio0_3 = pio0_3
         .into_unused_pin()
-        .into_gpio_pin(&gpio)
+        .into_gpio_pin(&p.gpio)
         .into_output();
 
     // Let's already initialize the durations that we're going to sleep for

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
 
     // Create the peripheral interfaces.
     let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    let     swm    = SWM::new(peripherals.SWM);
+    let     swm    = SWM::new(peripherals.SWM).split();
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     let     wkt    = WKT::new(peripherals.WKT);
 

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -27,16 +27,17 @@ entry!(main);
 fn main() -> ! {
     // Create the struct we're going to use to access all the peripherals. This
     // is unsafe, because we're only allowed to create one instance.
-    let mut peripherals = raw::Peripherals::take().unwrap();
+    let peripherals = raw::Peripherals::take().unwrap();
 
     // Create the peripheral interfaces.
     let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     let     swm    = SWM::new(peripherals.SWM).split();
-    let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+    let mut syscon = SYSCON::new(peripherals.SYSCON);
     let     wkt    = WKT::new(peripherals.WKT);
 
     // Other peripherals need to be initialized. Trying to use the API before
     // initializing them will actually lead to compile-time errors.
+    let mut syscon     = syscon.split();
     let     gpio       = gpio.enable(&mut syscon.handle);
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
     let mut wkt        = wkt.enable(&mut syscon.handle);

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     // Let's affirm that we haven't changed anything, and that PIO0_3 and SWCLK
     // are still in their initial states.
     let pio0_3 = swm.pins.pio0_3;
-    let swclk  = unsafe { swm.fixed_functions.swclk.affirm_default_state() };
+    let swclk  = swm.fixed_functions.swclk;
 
     // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
     let (_, pio0_3) = swclk

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
     // it is currently in.
     // Let's affirm that we haven't changed anything, and that PIO0_3 and SWCLK
     // are still in their initial states.
-    let pio0_3 = unsafe { swm.pins.pio0_3.affirm_default_state()           };
+    let pio0_3 = swm.pins.pio0_3;
     let swclk  = unsafe { swm.fixed_functions.swclk.affirm_default_state() };
 
     // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -31,11 +31,7 @@ fn main() -> ! {
 
     // We're going to need a clock for sleeping. Let's use the IRC-derived clock
     // that runs at 750 kHz.
-    let clock = syscon.irc_derived_clock.enable(
-        &mut syscon.handle,
-        syscon.irc,
-        syscon.ircout,
-    );
+    let clock = syscon.irc_derived_clock;
 
     // In the next step, we need to configure the pin PIO0_3 and its fixed
     // function SWCLK. The API tracks the state of both of those, to prevent any

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -25,12 +25,13 @@ use lpc82x_hal::usart::{
 entry!(main);
 
 fn main() -> ! {
-    let mut peripherals = raw::Peripherals::take().unwrap();
+    let peripherals = raw::Peripherals::take().unwrap();
 
-    let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+    let mut syscon = SYSCON::new(peripherals.SYSCON);
     let     swm    = SWM::new(peripherals.SWM).split();
     let     usart0 = USART::new(peripherals.USART0);
 
+    let mut syscon     = syscon.split();
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 
     // Set baud rate to 115200 baud

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -11,27 +11,17 @@ extern crate panic_abort;
 use cortex_m_rt::ExceptionFrame;
 
 use lpc82x_hal::prelude::*;
-use lpc82x_hal::{
-    SYSCON,
-    SWM,
-    raw,
-};
-use lpc82x_hal::usart::{
-    BaudRate,
-    USART,
-};
+use lpc82x_hal::Peripherals;
+use lpc82x_hal::usart::BaudRate;
 
 
 entry!(main);
 
 fn main() -> ! {
-    let peripherals = raw::Peripherals::take().unwrap();
+    let mut p = Peripherals::take().unwrap();
 
-    let mut syscon = SYSCON::new(peripherals.SYSCON);
-    let     swm    = SWM::new(peripherals.SWM).split();
-    let     usart0 = USART::new(peripherals.USART0);
-
-    let mut syscon     = syscon.split();
+    let     swm        = p.swm.split();
+    let mut syscon     = p.syscon.split();
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 
     // Set baud rate to 115200 baud
@@ -84,7 +74,7 @@ fn main() -> ! {
     // Initialize USART0. This should never fail, as the only reason `init`
     // returns a `Result::Err` is when the transmitter is busy, which it
     // shouldn't be right now.
-    let mut serial = usart0
+    let mut serial = p.usart0
         .enable(
             &baud_rate,
             &mut syscon.handle,

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -56,10 +56,8 @@ fn main() -> ! {
     // assign the USART's movable function to. For that, the pins need to be
     // unused. Since PIO0_0 and PIO0_4 are unused by default, we just have to
     // promise the API that we didn't change the default state up till now.
-    let pio0_0 = unsafe { swm.pins.pio0_0.affirm_default_state() }
-        .into_swm_pin();
-    let pio0_4 = unsafe { swm.pins.pio0_4.affirm_default_state() }
-        .into_swm_pin();
+    let pio0_0 = swm.pins.pio0_0.into_swm_pin();
+    let pio0_4 = swm.pins.pio0_4.into_swm_pin();
 
     // We also need to provide USART0's movable functions. Those need to be
     // unassigned, and since they are unassigned by default, we just need to

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let mut peripherals = raw::Peripherals::take().unwrap();
 
     let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    let     swm    = SWM::new(peripherals.SWM);
+    let     swm    = SWM::new(peripherals.SWM).split();
     let     usart0 = USART::new(peripherals.USART0);
 
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -20,9 +20,8 @@ entry!(main);
 fn main() -> ! {
     let mut p = Peripherals::take().unwrap();
 
-    let     swm        = p.swm.split();
-    let mut syscon     = p.syscon.split();
-    let mut swm_handle = swm.handle.enable(&mut syscon.handle);
+    let mut swm    = p.swm.split();
+    let mut syscon = p.syscon.split();
 
     // Set baud rate to 115200 baud
     //
@@ -68,8 +67,8 @@ fn main() -> ! {
     let u0_rxd = unsafe { swm.movable_functions.u0_rxd.affirm_default_state() };
     let u0_txd = unsafe { swm.movable_functions.u0_txd.affirm_default_state() };
 
-    let (u0_rxd, _) = u0_rxd.assign(pio0_0, &mut swm_handle);
-    let (u0_txd, _) = u0_txd.assign(pio0_4, &mut swm_handle);
+    let (u0_rxd, _) = u0_rxd.assign(pio0_0, &mut swm.handle);
+    let (u0_txd, _) = u0_txd.assign(pio0_4, &mut swm.handle);
 
     // Initialize USART0. This should never fail, as the only reason `init`
     // returns a `Result::Err` is when the transmitter is busy, which it

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -62,8 +62,8 @@ fn main() -> ! {
     // We also need to provide USART0's movable functions. Those need to be
     // unassigned, and since they are unassigned by default, we just need to
     // promise the API that we didn't change them.
-    let u0_rxd = unsafe { swm.movable_functions.u0_rxd.affirm_default_state() };
-    let u0_txd = unsafe { swm.movable_functions.u0_txd.affirm_default_state() };
+    let u0_rxd = swm.movable_functions.u0_rxd;
+    let u0_txd = swm.movable_functions.u0_txd;
 
     let (u0_rxd, _) = u0_rxd.assign(pio0_0, &mut swm.handle);
     let (u0_txd, _) = u0_txd.assign(pio0_4, &mut swm.handle);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -25,9 +25,10 @@
 //!
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     swm    = SWM::new(peripherals.SWM).split();
-//! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+//! let mut syscon = SYSCON::new(peripherals.SYSCON);
 //!
-//! let gpio_handle = gpio.enable(&mut syscon.handle);
+//! let mut syscon      = syscon.split();
+//! let     gpio_handle = gpio.enable(&mut syscon.handle);
 //!
 //! let pio0_12 = unsafe { swm.pins.pio0_12.affirm_default_state() }
 //!     .into_gpio_pin(&gpio_handle)
@@ -52,8 +53,9 @@
 //!
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     swm    = SWM::new(peripherals.SWM).split();
-//! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+//! let mut syscon = SYSCON::new(peripherals.SYSCON);
 //!
+//! let mut syscon     = syscon.split();
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 //!
 //! let vddcmp = unsafe {
@@ -201,9 +203,10 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let     swm    = SWM::new(peripherals.SWM).split();
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+    /// # let mut syscon = SYSCON::new(peripherals.SYSCON);
     /// #
-    /// # let gpio_handle = gpio.enable(&mut syscon.handle);
+    /// # let mut syscon      = syscon.split();
+    /// # let     gpio_handle = gpio.enable(&mut syscon.handle);
     /// #
     /// # let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
     /// #     .into_gpio_pin(&gpio_handle);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -42,9 +42,7 @@
 //! let mut syscon     = p.syscon.split();
 //! let mut swm        = p.swm.split();
 //!
-//! let vddcmp = unsafe {
-//!     swm.fixed_functions.vddcmp.affirm_default_state()
-//! };
+//! let vddcmp = swm.fixed_functions.vddcmp;
 //! let pio0_6 = swm.pins.pio0_6
 //!     .into_swm_pin();
 //! vddcmp.assign(pio0_6, &mut swm.handle);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -15,20 +15,13 @@
 //! extern crate lpc82x_hal;
 //!
 //! use lpc82x_hal::prelude::*;
-//! use lpc82x_hal::{
-//!     GPIO,
-//!     SWM,
-//!     SYSCON,
-//! };
+//! use lpc82x_hal::Peripherals;
 //!
-//! let mut peripherals = lpc82x::Peripherals::take().unwrap();
+//! let mut p = Peripherals::take().unwrap();
 //!
-//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(peripherals.SWM).split();
-//! let mut syscon = SYSCON::new(peripherals.SYSCON);
-//!
-//! let mut syscon      = syscon.split();
-//! let     gpio_handle = gpio.enable(&mut syscon.handle);
+//! let mut syscon      = p.syscon.split();
+//! let     swm         = p.swm.split();
+//! let     gpio_handle = p.gpio.enable(&mut syscon.handle);
 //!
 //! let pio0_12 = unsafe { swm.pins.pio0_12.affirm_default_state() }
 //!     .into_gpio_pin(&gpio_handle)
@@ -43,19 +36,12 @@
 //! extern crate lpc82x_hal;
 //!
 //! use lpc82x_hal::prelude::*;
-//! use lpc82x_hal::{
-//!     GPIO,
-//!     SWM,
-//!     SYSCON,
-//! };
+//! use lpc82x_hal::Peripherals;
 //!
-//! let mut peripherals = lpc82x::Peripherals::take().unwrap();
+//! let mut p = Peripherals::take().unwrap();
 //!
-//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(peripherals.SWM).split();
-//! let mut syscon = SYSCON::new(peripherals.SYSCON);
-//!
-//! let mut syscon     = syscon.split();
+//! let mut syscon     = p.syscon.split();
+//! let     swm        = p.swm.split();
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 //!
 //! let vddcmp = unsafe {
@@ -200,20 +186,13 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     /// # extern crate lpc82x;
     /// # extern crate lpc82x_hal;
     /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
+    /// # use lpc82x_hal::Peripherals;
     /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+    /// # let mut p = Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(peripherals.SWM).split();
-    /// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-    /// #
-    /// # let mut syscon      = syscon.split();
-    /// # let     gpio_handle = gpio.enable(&mut syscon.handle);
+    /// # let mut syscon      = p.syscon.split();
+    /// # let     swm         = p.swm.split();
+    /// # let     gpio_handle = p.gpio.enable(&mut syscon.handle);
     /// #
     /// # let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
     /// #     .into_gpio_pin(&gpio_handle);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -21,10 +21,9 @@
 //!
 //! let mut syscon      = p.syscon.split();
 //! let     swm         = p.swm.split();
-//! let     gpio_handle = p.gpio.enable(&mut syscon.handle);
 //!
 //! let pio0_12 = unsafe { swm.pins.pio0_12.affirm_default_state() }
-//!     .into_gpio_pin(&gpio_handle)
+//!     .into_gpio_pin(&p.gpio)
 //!     .into_output()
 //!     .set_high();
 //! ```
@@ -41,15 +40,14 @@
 //! let mut p = Peripherals::take().unwrap();
 //!
 //! let mut syscon     = p.syscon.split();
-//! let     swm        = p.swm.split();
-//! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
+//! let mut swm        = p.swm.split();
 //!
 //! let vddcmp = unsafe {
 //!     swm.fixed_functions.vddcmp.affirm_default_state()
 //! };
 //! let pio0_6 = unsafe { swm.pins.pio0_6.affirm_default_state() }
 //!     .into_swm_pin();
-//! vddcmp.assign(pio0_6, &mut swm_handle);
+//! vddcmp.assign(pio0_6, &mut swm.handle);
 //! ```
 //!
 //! [`GPIO`]: struct.GPIO.html
@@ -94,11 +92,11 @@ pub struct GPIO<State: InitState = init_state::Enabled> {
                _state: State,
 }
 
-impl GPIO<init_state::Unknown> {
+impl GPIO<init_state::Enabled> {
     pub(crate) fn new(gpio: raw::GPIO_PORT) -> Self {
         GPIO {
             gpio  : gpio,
-            _state: init_state::Unknown,
+            _state: init_state::Enabled,
         }
     }
 }
@@ -191,10 +189,9 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     /// #
     /// # let mut syscon      = p.syscon.split();
     /// # let     swm         = p.swm.split();
-    /// # let     gpio_handle = p.gpio.enable(&mut syscon.handle);
     /// #
     /// # let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
-    /// #     .into_gpio_pin(&gpio_handle);
+    /// #     .into_gpio_pin(&p.gpio);
     /// #
     /// use lpc82x_hal::prelude::*;
     ///

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -22,7 +22,7 @@
 //! let mut syscon      = p.syscon.split();
 //! let     swm         = p.swm.split();
 //!
-//! let pio0_12 = unsafe { swm.pins.pio0_12.affirm_default_state() }
+//! let pio0_12 = swm.pins.pio0_12
 //!     .into_gpio_pin(&p.gpio)
 //!     .into_output()
 //!     .set_high();
@@ -45,7 +45,7 @@
 //! let vddcmp = unsafe {
 //!     swm.fixed_functions.vddcmp.affirm_default_state()
 //! };
-//! let pio0_6 = unsafe { swm.pins.pio0_6.affirm_default_state() }
+//! let pio0_6 = swm.pins.pio0_6
 //!     .into_swm_pin();
 //! vddcmp.assign(pio0_6, &mut swm.handle);
 //! ```
@@ -190,7 +190,7 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     /// # let mut syscon      = p.syscon.split();
     /// # let     swm         = p.swm.split();
     /// #
-    /// # let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
+    /// # let pin = swm.pins.pio0_12
     /// #     .into_gpio_pin(&p.gpio);
     /// #
     /// use lpc82x_hal::prelude::*;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -24,7 +24,7 @@
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM).split();
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //!
 //! let gpio_handle = gpio.enable(&mut syscon.handle);
@@ -51,7 +51,7 @@
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM).split();
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //!
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -200,7 +200,7 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let     swm    = SWM::new(peripherals.SWM);
+    /// # let     swm    = SWM::new(peripherals.SWM).split();
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// # let gpio_handle = gpio.enable(&mut syscon.handle);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -118,6 +118,13 @@ impl GPIO<init_state::Unknown> {
     }
 }
 
+impl<State> GPIO<State> where State: InitState {
+    /// Return the raw peripheral
+    pub fn free(self) -> raw::GPIO_PORT {
+        self.gpio
+    }
+}
+
 impl<'gpio, State> GPIO<State> where State: init_state::NotEnabled {
     /// Enable the GPIO peripheral
     ///

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -95,8 +95,7 @@ pub struct GPIO<State: InitState = init_state::Enabled> {
 }
 
 impl GPIO<init_state::Unknown> {
-    /// Create an instance of `GPIO`
-    pub fn new(gpio: raw::GPIO_PORT) -> Self {
+    pub(crate) fn new(gpio: raw::GPIO_PORT) -> Self {
         GPIO {
             gpio  : gpio,
             _state: init_state::Unknown,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -108,7 +108,7 @@ impl<State> GPIO<State> where State: InitState {
     }
 }
 
-impl<'gpio, State> GPIO<State> where State: init_state::NotEnabled {
+impl<'gpio> GPIO<init_state::Disabled> {
     /// Enable the GPIO peripheral
     ///
     /// Enables the clock and clears the peripheral reset for the GPIO
@@ -135,7 +135,7 @@ impl<'gpio, State> GPIO<State> where State: init_state::NotEnabled {
     }
 }
 
-impl<State> GPIO<State> where State: init_state::NotDisabled {
+impl GPIO<init_state::Enabled> {
     /// Disable the GPIO peripheral
     ///
     /// This method is only available, if `gpio::Handle` is not already in the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,11 +152,12 @@
 //! // Create the peripheral interfaces.
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     swm    = SWM::new(peripherals.SWM).split();
-//! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+//! let mut syscon = SYSCON::new(peripherals.SYSCON);
 //! let     wkt    = WKT::new(peripherals.WKT);
 //!
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing them will actually lead to compile-time errors.
+//! let mut syscon      = syscon.split();
 //! let mut gpio_handle = gpio.enable(&mut syscon.handle);
 //! let mut swm_handle  = swm.handle.enable(&mut syscon.handle);
 //! let mut wkt         = wkt.enable(&mut syscon.handle);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,9 +147,7 @@
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing them will actually lead to compile-time errors.
 //! let mut syscon      = p.syscon.split();
-//! let mut gpio_handle = p.gpio.enable(&mut syscon.handle);
-//! let     swm         = p.swm.split();
-//! let mut swm_handle  = swm.handle.enable(&mut syscon.handle);
+//! let mut swm         = p.swm.split();
 //! let mut wkt         = p.wkt.enable(&mut syscon.handle);
 //!
 //! // We're going to need a clock for sleeping. Let's use the IRC-derived clock
@@ -172,10 +170,10 @@
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
 //! let (_, pio0_3) = swclk
-//!     .unassign(pio0_3, &mut swm_handle);
+//!     .unassign(pio0_3, &mut swm.handle);
 //! let mut pio0_3 = pio0_3
 //!     .into_unused_pin()
-//!     .into_gpio_pin(&gpio_handle)
+//!     .into_gpio_pin(&p.gpio)
 //!     .into_output();
 //!
 //! // Let's already initialize the durations that we're going to sleep for
@@ -353,9 +351,12 @@ pub mod init_state {
 
 
 /// Provides access to all peripherals
+///
+/// All peripheral states are set to their default states after hardware reset.
+/// See user manual, section 5.6.14.
 pub struct Peripherals {
-    /// General-purpose I/O
-    pub gpio: GPIO<init_state::Unknown>,
+    /// General-purpose I/O (GPIO)
+    pub gpio: GPIO<init_state::Enabled>,
 
     /// Power Management Unit
     pub pmu: PMU,
@@ -367,16 +368,22 @@ pub struct Peripherals {
     pub syscon: SYSCON,
 
     /// USART0
-    pub usart0: USART<raw::USART0, init_state::Unknown>,
+    pub usart0: USART<raw::USART0, init_state::Disabled>,
 
     /// USART1
-    pub usart1: USART<raw::USART1, init_state::Unknown>,
+    ///
+    /// The USART1 peripheral is disabled by default. See user manual, section
+    /// 5.6.14.
+    pub usart1: USART<raw::USART1, init_state::Disabled>,
 
     /// USART2
-    pub usart2: USART<raw::USART2, init_state::Unknown>,
+    ///
+    /// The USART2 peripheral is disabled by default. See user manual, section
+    /// 5.6.14.
+    pub usart2: USART<raw::USART2, init_state::Disabled>,
 
     /// Self-wake-up timer
-    pub wkt: WKT<init_state::Unknown>,
+    pub wkt: WKT<init_state::Disabled>,
 
     /// Analog-to-Digital Converter
     pub adc: raw::ADC,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,11 +152,7 @@
 //!
 //! // We're going to need a clock for sleeping. Let's use the IRC-derived clock
 //! // that runs at 750 kHz.
-//! let clock = syscon.irc_derived_clock.enable(
-//!     &mut syscon.handle,
-//!     syscon.irc,
-//!     syscon.ircout,
-//! );
+//! let clock = syscon.irc_derived_clock;
 //!
 //! // In the next step, we need to configure the pin PIO0_3 and its fixed
 //! // function SWCLK. The API tracks the state of both of those, to prevent any

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 //! // it is currently in.
 //! // Let's affirm that we haven't changed anything, and that PIO0_3 and SWCLK
 //! // are still in their initial states.
-//! let pio0_3 = unsafe { swm.pins.pio0_3.affirm_default_state()          };
+//! let pio0_3 = swm.pins.pio0_3;
 //! let swclk  = unsafe { swm.fixed_functions.swclk.affirm_default_state() };
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@
 //!
 //! // Create the peripheral interfaces.
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM).split();
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 //! let     wkt    = WKT::new(peripherals.WKT);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,12 +132,7 @@
 //! extern crate lpc82x_hal;
 //!
 //! use lpc82x_hal::prelude::*;
-//! use lpc82x_hal::{
-//!     GPIO,
-//!     SWM,
-//!     SYSCON,
-//!     WKT,
-//! };
+//! use lpc82x_hal::Peripherals;
 //! use lpc82x_hal::clock::Ticks;
 //! use lpc82x_hal::sleep::{
 //!     self,
@@ -147,20 +142,15 @@
 //!
 //! // Create the struct we're going to use to access all the peripherals. This
 //! // is unsafe, because we're only allowed to create one instance.
-//! let mut peripherals = lpc82x::Peripherals::take().unwrap();
-//!
-//! // Create the peripheral interfaces.
-//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     swm    = SWM::new(peripherals.SWM).split();
-//! let mut syscon = SYSCON::new(peripherals.SYSCON);
-//! let     wkt    = WKT::new(peripherals.WKT);
+//! let mut p = Peripherals::take().unwrap();
 //!
 //! // Other peripherals need to be initialized. Trying to use the API before
 //! // initializing them will actually lead to compile-time errors.
-//! let mut syscon      = syscon.split();
-//! let mut gpio_handle = gpio.enable(&mut syscon.handle);
+//! let mut syscon      = p.syscon.split();
+//! let mut gpio_handle = p.gpio.enable(&mut syscon.handle);
+//! let     swm         = p.swm.split();
 //! let mut swm_handle  = swm.handle.enable(&mut syscon.handle);
-//! let mut wkt         = wkt.enable(&mut syscon.handle);
+//! let mut wkt         = p.wkt.enable(&mut syscon.handle);
 //!
 //! // We're going to need a clock for sleeping. Let's use the IRC-derived clock
 //! // that runs at 750 kHz.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@
 //! // Let's affirm that we haven't changed anything, and that PIO0_3 and SWCLK
 //! // are still in their initial states.
 //! let pio0_3 = swm.pins.pio0_3;
-//! let swclk  = unsafe { swm.fixed_functions.swclk.affirm_default_state() };
+//! let swclk  = swm.fixed_functions.swclk;
 //!
 //! // Configure PIO0_3 as GPIO output, so we can use it to blink an LED.
 //! let (_, pio0_3) = swclk

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,15 +293,6 @@ pub mod init_state {
     pub trait InitState {}
 
 
-    /// Indicates that the hardware's state is currently unknown
-    ///
-    /// This is usually the initial state after the HAL API has been
-    /// initialized, as we don't know what happened before that.
-    pub struct Unknown;
-
-    impl InitState for Unknown {}
-
-
     /// Indicates that the hardware component is enabled
     ///
     /// This usually indicates that the hardware has been initialized and can be
@@ -315,34 +306,6 @@ pub mod init_state {
     pub struct Disabled;
 
     impl InitState for Disabled {}
-
-
-    /// Marks a hardware component as not being enabled
-    ///
-    /// This is a helper trait that is implemented for all states, except
-    /// [`Enabled`]. It is used to create `impl` blocks that define methods that
-    /// should be available in all states, except when the hardware component is
-    /// enabled.
-    ///
-    /// [`Enabled`]: struct.Enabled.html
-    pub trait NotEnabled: InitState {}
-
-    impl NotEnabled for Unknown {}
-    impl NotEnabled for Disabled {}
-
-
-    /// Marks a hardware component as not being disabled
-    ///
-    /// This is a helper trait that is implemented for all states, except
-    /// [`Disabled`]. It is used to create `impl` blocks that define methods
-    /// that should be available in all states, except when the hardware
-    /// component is disabled.
-    ///
-    /// [`Disabled`]: struct.Disabled.html
-    pub trait NotDisabled: InitState {}
-
-    impl NotDisabled for Unknown {}
-    impl NotDisabled for Enabled {}
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,3 +360,133 @@ pub mod init_state {
     impl NotDisabled for Unknown {}
     impl NotDisabled for Enabled {}
 }
+
+
+/// Provides access to all peripherals
+pub struct Peripherals {
+    /// General-purpose I/O
+    pub gpio: GPIO<init_state::Unknown>,
+
+    /// Power Management Unit
+    pub pmu: PMU,
+
+    /// Switch matrix
+    pub swm: SWM,
+
+    /// System configuration
+    pub syscon: SYSCON,
+
+    /// USART0
+    pub usart0: USART<raw::USART0, init_state::Unknown>,
+
+    /// USART1
+    pub usart1: USART<raw::USART1, init_state::Unknown>,
+
+    /// USART2
+    pub usart2: USART<raw::USART2, init_state::Unknown>,
+
+    /// Self-wake-up timer
+    pub wkt: WKT<init_state::Unknown>,
+
+    /// Analog-to-Digital Converter
+    pub adc: raw::ADC,
+
+    /// Analog comparator
+    pub cmp: raw::CMP,
+
+    /// CRC engine
+    pub crc: raw::CRC,
+
+    /// DMA controller
+    pub dma: raw::DMA,
+
+    /// DMA trigger mux
+    pub dmatrigmux: raw::DMATRIGMUX,
+
+    /// Flash controller
+    pub flashctrl: raw::FLASHCTRL,
+
+    /// I2C0-bus interface
+    pub i2c0: raw::I2C0,
+
+    /// I2C0-bus interface
+    pub i2c1: raw::I2C1,
+
+    /// I2C0-bus interface
+    pub i2c2: raw::I2C2,
+
+    /// I2C0-bus interface
+    pub i2c3: raw::I2C3,
+
+    /// Input multiplexing
+    pub inputmux: raw::INPUTMUX,
+
+    /// I/O configuration
+    pub iocon: raw::IOCON,
+
+    /// Multi-Rate Timer
+    pub mrt: raw::MRT,
+
+    /// Pin interrupt and pattern match engine
+    pub pin_int: raw::PIN_INT,
+
+    /// State Configurable Timer
+    pub sct: raw::SCT,
+
+    /// SPI0
+    pub spi0: raw::SPI0,
+
+    /// SPI1
+    pub spi1: raw::SPI1,
+
+    /// Windowed Watchdog Timer
+    pub wwdt: raw::WWDT,
+}
+
+impl Peripherals {
+    /// Take the peripherals
+    pub fn take() -> Option<Self> {
+        let p = raw::Peripherals::take()?;
+
+        Some(Self::new(p))
+    }
+
+    /// Steal the peripherals
+    pub unsafe fn steal() -> Self {
+        Self::new(raw::Peripherals::steal())
+    }
+
+    fn new(p: raw::Peripherals) -> Self {
+        Peripherals {
+            // HAL peripherals
+            gpio  : GPIO::new(p.GPIO_PORT),
+            pmu   : PMU::new(p.PMU),
+            swm   : SWM::new(p.SWM),
+            syscon: SYSCON::new(p.SYSCON),
+            usart0: USART::new(p.USART0),
+            usart1: USART::new(p.USART1),
+            usart2: USART::new(p.USART2),
+            wkt   : WKT::new(p.WKT),
+
+            /// Raw peripherals
+            adc       : p.ADC,
+            cmp       : p.CMP,
+            crc       : p.CRC,
+            dma       : p.DMA,
+            dmatrigmux: p.DMATRIGMUX,
+            flashctrl : p.FLASHCTRL,
+            i2c0      : p.I2C0,
+            i2c1      : p.I2C1,
+            i2c2      : p.I2C2,
+            i2c3      : p.I2C3,
+            inputmux  : p.INPUTMUX,
+            iocon     : p.IOCON,
+            mrt       : p.MRT,
+            pin_int   : p.PIN_INT,
+            sct       : p.SCT,
+            spi0      : p.SPI0,
+            spi1      : p.SPI1,
+            wwdt      : p.WWDT,
+        }
+    }
+}

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -61,6 +61,11 @@ impl PMU {
             low_power_clock: LowPowerClock::new(),
         }
     }
+
+    /// Return the raw peripheral
+    pub fn free(self) -> raw::PMU {
+        self.pmu
+    }
 }
 
 

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -47,8 +47,7 @@ pub struct PMU {
 }
 
 impl PMU {
-    /// Create an instance of `PMU`
-    pub fn new(pmu: raw::PMU) -> Self {
+    pub(crate) fn new(pmu: raw::PMU) -> Self {
         PMU { pmu }
     }
 

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -135,7 +135,7 @@ impl LowPowerClock<init_state::Disabled> {
     }
 }
 
-impl<State> LowPowerClock<State> where State: init_state::NotEnabled {
+impl LowPowerClock<init_state::Disabled> {
     /// Enable the low-power clock
     ///
     /// This method is only available if the low-power clock is not already
@@ -161,7 +161,7 @@ impl<State> LowPowerClock<State> where State: init_state::NotEnabled {
     }
 }
 
-impl<State> LowPowerClock<State> where State: init_state::NotDisabled {
+impl LowPowerClock<init_state::Enabled> {
     /// Disable the low-power clock
     ///
     /// This method is only available if the low-power clock is not already

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -15,7 +15,7 @@
 //! let mut core_peripherals = lpc82x::CorePeripherals::take().unwrap();
 //! let mut peripherals      = lpc82x::Peripherals::take().unwrap();
 //!
-//! let mut pmu = PMU::new(peripherals.PMU);
+//! let mut pmu = PMU::new(peripherals.PMU).split();
 //!
 //! // Enters sleep mode. Unless we set up some interrupts, we won't wake up
 //! // from this again.
@@ -42,29 +42,40 @@ use raw;
 
 
 /// Entry point to the PMU API
-///
-/// Provides access to all types that make up the PMU API. Please refer to the
-/// [module documentation] for more information.
-///
-/// [module documentation]: index.html
 pub struct PMU {
-    /// The handle to the PMU peripheral
-    pub handle: Handle,
-
-    /// The 10 kHz low-power clock
-    pub low_power_clock: LowPowerClock<init_state::Unknown>,
+    pmu: raw::PMU,
 }
 
 impl PMU {
     /// Create an instance of `PMU`
     pub fn new(pmu: raw::PMU) -> Self {
-        PMU {
+        PMU { pmu }
+    }
+
+    /// Splits the PMU API into its parts
+    pub fn split(self) -> Parts {
+        Parts {
             handle: Handle {
-                pmu: pmu,
+                pmu: self.pmu,
             },
             low_power_clock: LowPowerClock::new(),
         }
     }
+}
+
+
+/// The main API for the PMU peripheral
+///
+/// Provides access to all types that make up the PMU API. Please refer to the
+/// [module documentation] for more information.
+///
+/// [module documentation]: index.html
+pub struct Parts {
+    /// The handle to the PMU peripheral
+    pub handle: Handle,
+
+    /// The 10 kHz low-power clock
+    pub low_power_clock: LowPowerClock<init_state::Unknown>,
 }
 
 

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -79,7 +79,7 @@ pub struct Parts {
     pub handle: Handle,
 
     /// The 10 kHz low-power clock
-    pub low_power_clock: LowPowerClock<init_state::Unknown>,
+    pub low_power_clock: LowPowerClock<init_state::Disabled>,
 }
 
 
@@ -127,10 +127,10 @@ pub struct LowPowerClock<State: InitState = init_state::Enabled> {
     _state: State,
 }
 
-impl LowPowerClock<init_state::Unknown> {
+impl LowPowerClock<init_state::Disabled> {
     pub(crate) fn new() -> Self {
         LowPowerClock {
-            _state: init_state::Unknown,
+            _state: init_state::Disabled,
         }
     }
 }

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -10,12 +10,12 @@
 //! extern crate lpc82x;
 //! extern crate lpc82x_hal;
 //!
-//! use lpc82x_hal::PMU;
+//! use lpc82x_hal::Peripherals;
 //!
 //! let mut core_peripherals = lpc82x::CorePeripherals::take().unwrap();
-//! let mut peripherals      = lpc82x::Peripherals::take().unwrap();
+//! let mut peripherals      = Peripherals::take().unwrap();
 //!
-//! let mut pmu = PMU::new(peripherals.PMU).split();
+//! let mut pmu = peripherals.pmu.split();
 //!
 //! // Enters sleep mode. Unless we set up some interrupts, we won't wake up
 //! // from this again.

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -65,18 +65,14 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 /// use lpc82x_hal::prelude::*;
 /// use lpc82x_hal::{
 ///     sleep,
-///     SYSCON,
-///     WKT,
+///     Peripherals,
 /// };
 /// use lpc82x_hal::clock::Ticks;
 ///
-/// let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// let mut p = Peripherals::take().unwrap();
 ///
-/// let mut syscon = SYSCON::new(peripherals.SYSCON);
-/// let     wkt    = WKT::new(peripherals.WKT);
-///
-/// let mut syscon = syscon.split();
-/// let mut wkt    = wkt.enable(&mut syscon.handle);
+/// let mut syscon = p.syscon.split();
+/// let mut wkt    = p.wkt.enable(&mut syscon.handle);
 ///
 /// let clock = syscon.irc_derived_clock.enable(
 ///     &mut syscon.handle,
@@ -155,21 +151,16 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// use lpc82x_hal::prelude::*;
 /// use lpc82x_hal::{
 ///     sleep,
-///     PMU,
-///     SYSCON,
-///     WKT,
+///     Peripherals,
 /// };
 /// use lpc82x_hal::clock::Ticks;
 ///
 /// let mut core_peripherals = lpc82x::CorePeripherals::take().unwrap();
-/// let mut peripherals      = lpc82x::Peripherals::take().unwrap();
+/// let mut peripherals      = Peripherals::take().unwrap();
 ///
-/// let mut pmu    = PMU::new(peripherals.PMU).split();
-/// let mut syscon = SYSCON::new(peripherals.SYSCON);
-/// let     wkt    = WKT::new(peripherals.WKT);
-///
-/// let mut syscon = syscon.split();
-/// let mut wkt    = wkt.enable(&mut syscon.handle);
+/// let mut pmu    = peripherals.pmu.split();
+/// let mut syscon = peripherals.syscon.split();
+/// let mut wkt    = peripherals.wkt.enable(&mut syscon.handle);
 ///
 /// let clock = syscon.irc_derived_clock.enable(
 ///     &mut syscon.handle,

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -163,7 +163,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// let mut core_peripherals = lpc82x::CorePeripherals::take().unwrap();
 /// let mut peripherals      = lpc82x::Peripherals::take().unwrap();
 ///
-/// let mut pmu    = PMU::new(peripherals.PMU);
+/// let mut pmu    = PMU::new(peripherals.PMU).split();
 /// let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// let     wkt    = WKT::new(peripherals.WKT);
 ///

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -74,11 +74,7 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 /// let mut syscon = p.syscon.split();
 /// let mut wkt    = p.wkt.enable(&mut syscon.handle);
 ///
-/// let clock = syscon.irc_derived_clock.enable(
-///     &mut syscon.handle,
-///     syscon.irc,
-///     syscon.ircout,
-/// );
+/// let clock = syscon.irc_derived_clock;
 ///
 /// let mut sleep = sleep::Busy::prepare(&mut wkt);
 ///
@@ -162,11 +158,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// let mut syscon = peripherals.syscon.split();
 /// let mut wkt    = peripherals.wkt.enable(&mut syscon.handle);
 ///
-/// let clock = syscon.irc_derived_clock.enable(
-///     &mut syscon.handle,
-///     syscon.irc,
-///     syscon.ircout,
-/// );
+/// let clock = syscon.irc_derived_clock;
 ///
 /// let mut sleep = sleep::Regular::prepare(
 ///     &mut core_peripherals.NVIC,

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -72,10 +72,11 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 ///
 /// let mut peripherals = lpc82x::Peripherals::take().unwrap();
 ///
-/// let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// let     wkt    = WKT::new(peripherals.WKT);
 ///
-/// let mut wkt = wkt.enable(&mut syscon.handle);
+/// let mut syscon = syscon.split();
+/// let mut wkt    = wkt.enable(&mut syscon.handle);
 ///
 /// let clock = syscon.irc_derived_clock.enable(
 ///     &mut syscon.handle,
@@ -164,10 +165,11 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// let mut peripherals      = lpc82x::Peripherals::take().unwrap();
 ///
 /// let mut pmu    = PMU::new(peripherals.PMU).split();
-/// let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// let     wkt    = WKT::new(peripherals.WKT);
 ///
-/// let mut wkt = wkt.enable(&mut syscon.handle);
+/// let mut syscon = syscon.split();
+/// let mut wkt    = wkt.enable(&mut syscon.handle);
 ///
 /// let clock = syscon.irc_derived_clock.enable(
 ///     &mut syscon.handle,

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -328,8 +328,9 @@ pins!(
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// #
+/// # let mut syscon     = syscon.split();
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 /// #
 /// // Reassure the API that the pin is in its default state, i.e. unused.
@@ -372,12 +373,13 @@ pins!(
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// #
 /// // To use general-purpose I/O, we need to enable the GPIO peripheral. The
 /// // call to `into_gpio_pin` below enforces this by requiring a reference to
 /// // an enabled GPIO handle.
-/// let gpio_handle = gpio.enable(&mut syscon.handle);
+/// let mut syscon      = syscon.split();
+/// let     gpio_handle = gpio.enable(&mut syscon.handle);
 ///
 /// // Affirm that pin is unused, then transition to the GPIO state
 /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
@@ -413,9 +415,10 @@ pins!(
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// #
-/// # let gpio_handle = gpio.enable(&mut syscon.handle);
+/// # let mut syscon      = syscon.split();
+/// # let     gpio_handle = gpio.enable(&mut syscon.handle);
 /// #
 /// # let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
 /// #     .into_gpio_pin(&gpio_handle);
@@ -495,8 +498,9 @@ pins!(
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// #
+/// # let mut syscon     = syscon.split();
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 /// #
 /// # let xtalout = unsafe {
@@ -550,8 +554,9 @@ pins!(
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 /// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
 /// #
+/// # let mut syscon     = syscon.split();
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 /// #
 /// # let adc_2 = unsafe {
@@ -636,12 +641,13 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinTrait {
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+    /// # let mut syscon = SYSCON::new(peripherals.SYSCON);
     /// # let mut swm    = SWM::new(peripherals.SWM).split();
     /// #
     /// # let swclk = unsafe {
     /// #     swm.fixed_functions.swclk.affirm_default_state()
     /// # };
+    /// # let mut syscon     = syscon.split();
     /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
     /// #
     /// // These pins are in the unknown state. As long as that's the case, we
@@ -701,7 +707,8 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+    /// # let mut syscon = SYSCON::new(peripherals.SYSCON);
+    /// # let mut syscon = syscon.split();
     /// #
     /// let gpio = GPIO::new(peripherals.GPIO_PORT);
     /// let swm  = SWM::new(peripherals.SWM).split();

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -316,9 +316,7 @@ pins!(
 /// # let mut swm        = p.swm.split();
 /// #
 /// // Assign a movable function to this pin
-/// let clkout = unsafe {
-///     swm.movable_functions.clkout.affirm_default_state()
-/// };
+/// let clkout = swm.movable_functions.clkout;
 /// let (_, pin) = clkout.assign(
 ///     swm.pins.pio0_12.into_swm_pin(),
 ///     &mut swm.handle,
@@ -464,15 +462,9 @@ pins!(
 /// # let xtalout = unsafe {
 /// #     swm.fixed_functions.xtalout.affirm_default_state()
 /// # };
-/// # let u0_rxd = unsafe {
-/// #     swm.movable_functions.u0_rxd.affirm_default_state()
-/// # };
-/// # let u1_rxd = unsafe {
-/// #     swm.movable_functions.u1_rxd.affirm_default_state()
-/// # };
-/// # let u0_txd = unsafe {
-/// #     swm.movable_functions.u0_txd.affirm_default_state()
-/// # };
+/// # let u0_rxd = swm.movable_functions.u0_rxd;
+/// # let u1_rxd = swm.movable_functions.u1_rxd;
+/// # let u0_txd = swm.movable_functions.u0_txd;
 /// #
 /// // Put PIO0_9 into the SWM state
 /// let pin = swm.pins.pio0_9
@@ -1026,7 +1018,7 @@ macro_rules! movable_functions {
         /// [`SWM`]: struct.SWM.html
         #[allow(missing_docs)]
         pub struct MovableFunctions {
-            $(pub $field: Function<$type, state::Unknown>,)*
+            $(pub $field: Function<$type, state::Unassigned>,)*
         }
 
         impl MovableFunctions {
@@ -1034,7 +1026,7 @@ macro_rules! movable_functions {
                 MovableFunctions {
                     $($field: Function {
                         ty    : $type(()),
-                        _state: state::Unknown,
+                        _state: state::Unassigned,
                     },)*
                 }
             }
@@ -1045,10 +1037,6 @@ macro_rules! movable_functions {
             /// Represents a movable function
             #[allow(non_camel_case_types)]
             pub struct $type(());
-
-            impl DefaultState for $type {
-                type DefaultState = state::Unassigned;
-            }
 
             impl_function!($type, $kind, $reg_name, $reg_field, PIO0_0 );
             impl_function!($type, $kind, $reg_name, $reg_field, PIO0_1 );

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -25,8 +25,7 @@ pub struct SWM {
 }
 
 impl SWM {
-    /// Create an instance of `SWM`
-    pub fn new(swm: raw::SWM) -> Self {
+    pub(crate) fn new(swm: raw::SWM) -> Self {
         SWM { swm }
     }
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -294,11 +294,11 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::SWM;
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let swm = SWM::new(peripherals.SWM).split();
+/// # let swm = p.swm.split();
 /// #
 /// use lpc82x_hal::swm::{
 ///     PIO0_12,
@@ -323,19 +323,12 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::{
-/// #     GPIO,
-/// #     SWM,
-/// #     SYSCON,
-/// # };
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-/// #
-/// # let mut syscon     = syscon.split();
+/// # let mut syscon     = p.syscon.split();
+/// # let     swm        = p.swm.split();
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 /// #
 /// // Reassure the API that the pin is in its default state, i.e. unused.
@@ -368,23 +361,16 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::{
-/// #     GPIO,
-/// #     SWM,
-/// #     SYSCON,
-/// # };
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
-/// #
-/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
+/// # let mut p = Peripherals::take().unwrap();
 /// #
 /// // To use general-purpose I/O, we need to enable the GPIO peripheral. The
 /// // call to `into_gpio_pin` below enforces this by requiring a reference to
 /// // an enabled GPIO handle.
-/// let mut syscon      = syscon.split();
-/// let     gpio_handle = gpio.enable(&mut syscon.handle);
+/// let mut syscon      = p.syscon.split();
+/// let     swm         = p.swm.split();
+/// let     gpio_handle = p.gpio.enable(&mut syscon.handle);
 ///
 /// // Affirm that pin is unused, then transition to the GPIO state
 /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
@@ -410,20 +396,13 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::{
-/// #     GPIO,
-/// #     SWM,
-/// #     SYSCON,
-/// # };
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-/// #
-/// # let mut syscon      = syscon.split();
-/// # let     gpio_handle = gpio.enable(&mut syscon.handle);
+/// # let mut syscon      = p.syscon.split();
+/// # let     swm         = p.swm.split();
+/// # let     gpio_handle = p.gpio.enable(&mut syscon.handle);
 /// #
 /// # let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
 /// #     .into_gpio_pin(&gpio_handle);
@@ -460,11 +439,11 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::SWM;
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let swm = SWM::new(peripherals.SWM).split();
+/// # let swm = p.swm.split();
 /// #
 /// // Affirm that the pin is unused, then transition to the SWM state
 /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
@@ -493,19 +472,12 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::{
-/// #     GPIO,
-/// #     SWM,
-/// #     SYSCON,
-/// # };
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-/// #
-/// # let mut syscon     = syscon.split();
+/// # let mut syscon     = p.syscon.split();
+/// # let     swm        = p.swm.split();
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 /// #
 /// # let xtalout = unsafe {
@@ -549,19 +521,12 @@ pins!(
 /// # extern crate lpc82x;
 /// # extern crate lpc82x_hal;
 /// #
-/// # use lpc82x_hal::{
-/// #     GPIO,
-/// #     SWM,
-/// #     SYSCON,
-/// # };
+/// # use lpc82x_hal::Peripherals;
 /// #
-/// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+/// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM).split();
-/// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-/// #
-/// # let mut syscon     = syscon.split();
+/// # let mut syscon     = p.syscon.split();
+/// # let     swm        = p.swm.split();
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 /// #
 /// # let adc_2 = unsafe {
@@ -637,23 +602,17 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinTrait {
     /// # extern crate lpc82x;
     /// # extern crate lpc82x_hal;
     /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
+    /// # use lpc82x_hal::Peripherals;
     /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+    /// # let mut p = Peripherals::take().unwrap();
     /// #
-    /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-    /// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-    /// # let mut swm    = SWM::new(peripherals.SWM).split();
+    /// # let mut syscon     = p.syscon.split();
+    /// # let     swm        = p.swm.split();
+    /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
     /// #
     /// # let swclk = unsafe {
     /// #     swm.fixed_functions.swclk.affirm_default_state()
     /// # };
-    /// # let mut syscon     = syscon.split();
-    /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
     /// #
     /// // These pins are in the unknown state. As long as that's the case, we
     /// // can't do anything useful with them.
@@ -704,21 +663,15 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// # extern crate lpc82x;
     /// # extern crate lpc82x_hal;
     /// #
-    /// # use lpc82x_hal::{
-    /// #     GPIO,
-    /// #     SWM,
-    /// #     SYSCON,
-    /// # };
+    /// # use lpc82x_hal::Peripherals;
     /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+    /// # let mut p = Peripherals::take().unwrap();
     /// #
-    /// # let mut syscon = SYSCON::new(peripherals.SYSCON);
-    /// # let mut syscon = syscon.split();
+    /// # let mut syscon = p.syscon.split();
     /// #
-    /// let gpio = GPIO::new(peripherals.GPIO_PORT);
-    /// let swm  = SWM::new(peripherals.SWM).split();
+    /// let swm = p.swm.split();
     ///
-    /// let gpio_handle = gpio.enable(&mut syscon.handle);
+    /// let gpio_handle = p.gpio.enable(&mut syscon.handle);
     ///
     /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
     ///     .into_gpio_pin(&gpio_handle);
@@ -762,11 +715,11 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// # extern crate lpc82x;
     /// # extern crate lpc82x_hal;
     /// #
-    /// # use lpc82x_hal::SWM;
+    /// # use lpc82x_hal::Peripherals;
     /// #
-    /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
+    /// # let mut p = Peripherals::take().unwrap();
     /// #
-    /// let swm = SWM::new(peripherals.SWM).split();
+    /// let swm = p.swm.split();
     ///
     /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
     ///     .into_swm_pin();

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -39,6 +39,11 @@ impl SWM {
             fixed_functions  : FixedFunctions::new(),
         }
     }
+
+    /// Return the raw peripheral
+    pub fn free(self) -> raw::SWM {
+        self.swm
+    }
 }
 
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -842,25 +842,6 @@ pub struct Function<T, State> {
     _state: State,
 }
 
-impl<T> Function<T, state::Unknown> where T: DefaultState {
-    /// Affirm that the movable function is in its default state
-    ///
-    /// By calling this method, the user promises that the movable function is
-    /// in its default state. This is safe to do, if nothing has changed that
-    /// state before the HAL has been initialized.
-    ///
-    /// If the movable function's state has been changed by any other means than
-    /// the HAL API, then the user must use those means to return the movable
-    /// function to its default state, as specified in the user manual, before
-    /// calling this method.
-    pub unsafe fn affirm_default_state(self) -> Function<T, T::DefaultState> {
-        Function {
-            ty    : self.ty,
-            _state: state::State::new(),
-        }
-    }
-}
-
 impl<T> Function<T, state::Unassigned> {
     /// Assign the movable function to a pin
     ///
@@ -921,13 +902,6 @@ impl<T, P> Function<T, state::Assigned<P>> {
 
         (function, pin.unassign())
     }
-}
-
-
-/// Implemented by all functions
-pub trait DefaultState {
-    /// The default state of this function
-    type DefaultState: state::State;
 }
 
 
@@ -1243,17 +1217,6 @@ pub mod state {
         /// This method is intended for internal use. Any changes to this method
         /// won't be considered breaking changes.
         fn new() -> Self;
-    }
-
-
-    /// Indicates that the current state of the movable function is unknown
-    ///
-    /// This is the case after the HAL is initialized, as we can't know what
-    /// happened before that.
-    pub struct Unknown;
-
-    impl State for Unknown {
-        fn new() -> Self { Unknown }
     }
 
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -19,8 +19,31 @@ use syscon;
 use self::pin_state::PinState;
 
 
-/// Interface to the switch matrix (SWM)
+/// Entry point to the switch matrix API
 pub struct SWM {
+    swm: raw::SWM,
+}
+
+impl SWM {
+    /// Create an instance of `SWM`
+    pub fn new(swm: raw::SWM) -> Self {
+        SWM { swm }
+    }
+
+    /// Split the SWM API into its parts
+    pub fn split(self) -> Parts {
+        Parts {
+            handle           : Handle::new(self.swm),
+            pins             : Pins::new(),
+            movable_functions: MovableFunctions::new(),
+            fixed_functions  : FixedFunctions::new(),
+        }
+    }
+}
+
+
+/// Interface to the switch matrix (SWM)
+pub struct Parts {
     /// Main SWM API
     pub handle: Handle<init_state::Unknown>,
 
@@ -32,18 +55,6 @@ pub struct SWM {
 
     /// Fixed functions
     pub fixed_functions: FixedFunctions,
-}
-
-impl SWM {
-    /// Create an instance of `SWM`
-    pub fn new(swm: raw::SWM) -> Self {
-        SWM {
-            handle           : Handle::new(swm),
-            pins             : Pins::new(),
-            movable_functions: MovableFunctions::new(),
-            fixed_functions  : FixedFunctions::new(),
-        }
-    }
 }
 
 
@@ -282,7 +293,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let swm = SWM::new(peripherals.SWM);
+/// # let swm = SWM::new(peripherals.SWM).split();
 /// #
 /// use lpc82x_hal::swm::{
 ///     PIO0_12,
@@ -316,7 +327,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM).split();
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -360,7 +371,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM).split();
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// // To use general-purpose I/O, we need to enable the GPIO peripheral. The
@@ -401,7 +412,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM).split();
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let gpio_handle = gpio.enable(&mut syscon.handle);
@@ -445,7 +456,7 @@ pins!(
 /// #
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
-/// # let swm = SWM::new(peripherals.SWM);
+/// # let swm = SWM::new(peripherals.SWM).split();
 /// #
 /// // Affirm that the pin is unused, then transition to the SWM state
 /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
@@ -483,7 +494,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM).split();
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -538,7 +549,7 @@ pins!(
 /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
 /// #
 /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-/// # let     swm    = SWM::new(peripherals.SWM);
+/// # let     swm    = SWM::new(peripherals.SWM).split();
 /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
 /// #
 /// # let mut swm_handle = swm.handle.enable(&mut syscon.handle);
@@ -626,7 +637,7 @@ impl<T> Pin<T, pin_state::Unknown> where T: PinTrait {
     /// #
     /// # let     gpio   = GPIO::new(peripherals.GPIO_PORT);
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-    /// # let mut swm    = SWM::new(peripherals.SWM);
+    /// # let mut swm    = SWM::new(peripherals.SWM).split();
     /// #
     /// # let swclk = unsafe {
     /// #     swm.fixed_functions.swclk.affirm_default_state()
@@ -693,7 +704,7 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// # let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
     /// #
     /// let gpio = GPIO::new(peripherals.GPIO_PORT);
-    /// let swm  = SWM::new(peripherals.SWM);
+    /// let swm  = SWM::new(peripherals.SWM).split();
     ///
     /// let gpio_handle = gpio.enable(&mut syscon.handle);
     ///
@@ -743,7 +754,7 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     /// #
     /// # let mut peripherals = lpc82x::Peripherals::take().unwrap();
     /// #
-    /// let swm = SWM::new(peripherals.SWM);
+    /// let swm = SWM::new(peripherals.SWM).split();
     ///
     /// let pin = unsafe { swm.pins.pio0_12.affirm_default_state() }
     ///     .into_swm_pin();

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -77,7 +77,7 @@ impl Handle<init_state::Enabled> {
     }
 }
 
-impl<State> Handle<State> where State: init_state::NotEnabled {
+impl Handle<init_state::Disabled> {
     /// Enable the switch matrix
     ///
     /// This method is only available, if `swm::Handle` is not already in the
@@ -100,7 +100,7 @@ impl<State> Handle<State> where State: init_state::NotEnabled {
     }
 }
 
-impl<State> Handle<State> where State: init_state::NotDisabled {
+impl Handle<init_state::Enabled> {
     /// Disable the switch matrix
     ///
     /// This method is only available, if `swm::Handle` is not already in the

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -459,9 +459,7 @@ pins!(
 /// # let mut syscon     = p.syscon.split();
 /// # let mut swm        = p.swm.split();
 /// #
-/// # let xtalout = unsafe {
-/// #     swm.fixed_functions.xtalout.affirm_default_state()
-/// # };
+/// # let xtalout = swm.fixed_functions.xtalout;
 /// # let u0_rxd = swm.movable_functions.u0_rxd;
 /// # let u1_rxd = swm.movable_functions.u1_rxd;
 /// # let u0_txd = swm.movable_functions.u0_txd;
@@ -501,9 +499,7 @@ pins!(
 /// # let mut syscon     = p.syscon.split();
 /// # let mut swm        = p.swm.split();
 /// #
-/// # let adc_2 = unsafe {
-/// #     swm.fixed_functions.adc_2.affirm_default_state()
-/// # };
+/// # let adc_2 = swm.fixed_functions.adc_2;
 /// #
 /// // Transition pin into ADC state
 /// let pio0_14 = swm.pins.pio0_14
@@ -1165,7 +1161,7 @@ macro_rules! fixed_functions {
         /// [`SWM`]: struct.SWM.html
         #[allow(missing_docs)]
         pub struct FixedFunctions {
-            $(pub $field: Function<$type, state::Unknown>,)*
+            $(pub $field: Function<$type, $default_state>,)*
         }
 
         impl FixedFunctions {
@@ -1184,10 +1180,6 @@ macro_rules! fixed_functions {
             /// Represents a fixed function
             #[allow(non_camel_case_types)]
             pub struct $type(());
-
-            impl DefaultState for $type {
-                type DefaultState = $default_state;
-            }
 
             impl FunctionTrait<$pin> for $type {
                 type Kind = $kind;

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -166,7 +166,7 @@ macro_rules! pins {
         $field:ident,
         $type:ident,
         $id:expr,
-        $default_state:ty,
+        $default_state_ty:ty,
         $default_state_val:expr;
     )*) => {
         /// Provides access to all pins
@@ -187,7 +187,7 @@ macro_rules! pins {
         /// [`GPIO`]: struct.GPIO.html
         #[allow(missing_docs)]
         pub struct Pins {
-            $(pub $field: Pin<$type, $default_state>,)*
+            $(pub $field: Pin<$type, $default_state_ty>,)*
         }
 
         impl Pins {
@@ -220,7 +220,7 @@ macro_rules! pins {
             pub struct $type(());
 
             impl PinTrait for $type {
-                type DefaultState = $default_state;
+                type DefaultState = $default_state_ty;
 
                 const ID  : u8  = $id;
                 const MASK: u32 = 0x1 << $id;

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -110,7 +110,7 @@ pub struct Parts<'syscon> {
     pub uartfrg: UARTFRG<'syscon>,
 
     /// The 750 kHz IRC-derived clock
-    pub irc_derived_clock: IrcDerivedClock<init_state::Unknown>,
+    pub irc_derived_clock: IrcDerivedClock<init_state::Enabled>,
 }
 
 
@@ -459,10 +459,10 @@ pub struct IrcDerivedClock<State: InitState = init_state::Enabled> {
     _state: State,
 }
 
-impl IrcDerivedClock<init_state::Unknown> {
+impl IrcDerivedClock<init_state::Enabled> {
     pub(crate) fn new() -> Self {
         IrcDerivedClock {
-            _state: init_state::Unknown,
+            _state: init_state::Enabled,
         }
     }
 }

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -65,6 +65,11 @@ impl SYSCON {
             irc_derived_clock: IrcDerivedClock::new(),
         }
     }
+
+    /// Return the raw peripheral
+    pub fn free(self) -> raw::SYSCON {
+        self.syscon
+    }
 }
 
 

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -32,8 +32,7 @@ pub struct SYSCON {
 }
 
 impl SYSCON {
-    /// Create an instance of `SYSCON`
-    pub fn new(syscon: raw::SYSCON) -> Self {
+    pub(crate) fn new(syscon: raw::SYSCON) -> Self {
         SYSCON { syscon }
     }
 

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -26,10 +26,52 @@ use raw::syscon::{
 };
 
 
-/// Entry point to the SYSCON API.
+/// Entry point to the SYSCON API
+pub struct SYSCON {
+    syscon: raw::SYSCON,
+}
+
+impl SYSCON {
+    /// Create an instance of `SYSCON`
+    pub fn new(syscon: raw::SYSCON) -> Self {
+        SYSCON { syscon }
+    }
+
+    /// Split the API into its parts
+    pub fn split(&mut self) -> Parts {
+        Parts {
+            handle: Handle {
+                pdruncfg     : &self.syscon.pdruncfg,
+                presetctrl   : &self.syscon.presetctrl,
+                sysahbclkctrl: &self.syscon.sysahbclkctrl,
+            },
+
+            bod    : BOD(PhantomData),
+            flash  : FLASH(PhantomData),
+            irc    : IRC(PhantomData),
+            ircout : IRCOUT(PhantomData),
+            mtb    : MTB(PhantomData),
+            ram0_1 : RAM0_1(PhantomData),
+            rom    : ROM(PhantomData),
+            sysosc : SYSOSC(PhantomData),
+            syspll : SYSPLL(PhantomData),
+            uartfrg: UARTFRG {
+                uartclkdiv : &self.syscon.uartclkdiv,
+                uartfrgdiv : &self.syscon.uartfrgdiv,
+                uartfrgmult: &self.syscon.uartfrgmult,
+
+            },
+
+            irc_derived_clock: IrcDerivedClock::new(),
+        }
+    }
+}
+
+
+/// The main API for the SYSCON peripheral
 ///
 /// Provides access to all types that make up the SYSCON API.
-pub struct SYSCON<'syscon> {
+pub struct Parts<'syscon> {
     /// The handle to the SYSCON peripheral
     pub handle: Handle<'syscon>,
 
@@ -65,37 +107,6 @@ pub struct SYSCON<'syscon> {
 
     /// The 750 kHz IRC-derived clock
     pub irc_derived_clock: IrcDerivedClock<init_state::Unknown>,
-}
-
-impl<'syscon> SYSCON<'syscon> {
-    /// Create an instance of `SYSCON`
-    pub fn new(syscon: &'syscon mut raw::SYSCON) -> Self {
-        SYSCON {
-            handle: Handle {
-                pdruncfg     : &syscon.pdruncfg,
-                presetctrl   : &syscon.presetctrl,
-                sysahbclkctrl: &syscon.sysahbclkctrl,
-            },
-
-            bod    : BOD(PhantomData),
-            flash  : FLASH(PhantomData),
-            irc    : IRC(PhantomData),
-            ircout : IRCOUT(PhantomData),
-            mtb    : MTB(PhantomData),
-            ram0_1 : RAM0_1(PhantomData),
-            rom    : ROM(PhantomData),
-            sysosc : SYSOSC(PhantomData),
-            syspll : SYSPLL(PhantomData),
-            uartfrg: UARTFRG {
-                uartclkdiv : &syscon.uartclkdiv,
-                uartfrgdiv : &syscon.uartfrgdiv,
-                uartfrgmult: &syscon.uartfrgmult,
-
-            },
-
-            irc_derived_clock: IrcDerivedClock::new(),
-        }
-    }
 }
 
 

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -467,7 +467,7 @@ impl IrcDerivedClock<init_state::Enabled> {
     }
 }
 
-impl<State> IrcDerivedClock<State> where State: init_state::NotEnabled {
+impl IrcDerivedClock<init_state::Disabled> {
     /// Enable the IRC-derived clock
     ///
     /// This method is only available if the IRC-derived clock is not already

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -150,6 +150,13 @@ impl<UsartX> USART<UsartX, init_state::Unknown>
     }
 }
 
+impl<UsartX, State> USART<UsartX, State> where State: InitState {
+    /// Return the raw peripheral
+    pub fn free(self) -> UsartX {
+        self.usart
+    }
+}
+
 impl<UsartX, State> USART<UsartX, State>
     where
         UsartX: Peripheral,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -55,8 +55,8 @@
 //! // assign the USART's movable function to. For that, the pins need to be
 //! // unused. Since PIO0_0 and PIO0_4 are unused by default, we just have to
 //! // promise the API that we didn't change the default state up till now.
-//! let pio0_0 = unsafe { swm.pins.pio0_0.affirm_default_state() };
-//! let pio0_4 = unsafe { swm.pins.pio0_4.affirm_default_state() };
+//! let pio0_0 = swm.pins.pio0_0;
+//! let pio0_4 = swm.pins.pio0_4;
 //!
 //! // We also need to provide USART0's movable functions. Those need to be
 //! // unassigned, and since they are unassigned by default, we just need to

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -11,24 +11,16 @@
 //! extern crate lpc82x_hal;
 //!
 //! use lpc82x_hal::prelude::*;
-//! use lpc82x_hal::{
-//!     GPIO,
-//!     SYSCON,
-//!     SWM,
-//! };
+//! use lpc82x_hal::Peripherals;
 //! use lpc82x_hal::usart::{
 //!     BaudRate,
 //!     USART,
 //! };
 //!
-//! let mut peripherals = lpc82x::Peripherals::take().unwrap();
+//! let mut p = Peripherals::take().unwrap();
 //!
-//! let mut syscon = SYSCON::new(peripherals.SYSCON);
-//! let     swm    = SWM::new(peripherals.SWM).split();
-//! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
-//! let     usart0 = USART::new(peripherals.USART0);
-//!
-//! let mut syscon     = syscon.split();
+//! let mut syscon     = p.syscon.split();
+//! let     swm        = p.swm.split();
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 //!
 //! // Set baud rate to 115200 baud
@@ -83,7 +75,7 @@
 //! // Initialize USART0. This should never fail, as the only reason `init`
 //! // returns a `Result::Err` is when the transmitter is busy, which it
 //! // shouldn't be right now.
-//! let mut serial = usart0
+//! let mut serial = p.usart0
 //!     .enable(
 //!         &baud_rate,
 //!         &mut syscon.handle,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -147,11 +147,7 @@ impl<UsartX, State> USART<UsartX, State> where State: InitState {
     }
 }
 
-impl<UsartX, State> USART<UsartX, State>
-    where
-        UsartX: Peripheral,
-        State : init_state::NotEnabled
-{
+impl<UsartX> USART<UsartX, init_state::Disabled> where UsartX: Peripheral {
     /// Enable a USART peripheral
     ///
     /// This method is only available, if `USART` is not already in the
@@ -249,11 +245,7 @@ impl<UsartX, State> USART<UsartX, State>
     }
 }
 
-impl<UsartX, State> USART<UsartX, State>
-    where
-        UsartX: Peripheral,
-        State : init_state::NotDisabled
-{
+impl<UsartX> USART<UsartX, init_state::Enabled> where UsartX: Peripheral {
     /// Disable a USART peripheral
     ///
     /// This method is only available, if `USART` is not already in the

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -20,8 +20,7 @@
 //! let mut p = Peripherals::take().unwrap();
 //!
 //! let mut syscon     = p.syscon.split();
-//! let     swm        = p.swm.split();
-//! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
+//! let mut swm        = p.swm.split();
 //!
 //! // Set baud rate to 115200 baud
 //! //
@@ -69,8 +68,8 @@
 //!     swm.movable_functions.u0_txd.affirm_default_state()
 //! };
 //!
-//! let (u0_rxd, _) = u0_rxd.assign(pio0_0.into_swm_pin(), &mut swm_handle);
-//! let (u0_txd, _) = u0_txd.assign(pio0_4.into_swm_pin(), &mut swm_handle);
+//! let (u0_rxd, _) = u0_rxd.assign(pio0_0.into_swm_pin(), &mut swm.handle);
+//! let (u0_txd, _) = u0_txd.assign(pio0_4.into_swm_pin(), &mut swm.handle);
 //!
 //! // Initialize USART0. This should never fail, as the only reason `init`
 //! // returns a `Result::Err` is when the transmitter is busy, which it
@@ -130,13 +129,13 @@ pub struct USART<UsartX, State : InitState = init_state::Enabled> {
     _state: State,
 }
 
-impl<UsartX> USART<UsartX, init_state::Unknown>
+impl<UsartX> USART<UsartX, init_state::Disabled>
     where UsartX: Peripheral,
 {
     pub(crate) fn new(usart: UsartX) -> Self {
         USART {
             usart : usart,
-            _state: init_state::Unknown,
+            _state: init_state::Disabled,
         }
     }
 }

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -23,11 +23,12 @@
 //!
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
-//! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+//! let mut syscon = SYSCON::new(peripherals.SYSCON);
 //! let     swm    = SWM::new(peripherals.SWM).split();
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     usart0 = USART::new(peripherals.USART0);
 //!
+//! let mut syscon     = syscon.split();
 //! let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 //!
 //! // Set baud rate to 115200 baud

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -24,7 +24,7 @@
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
 //! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
-//! let     swm    = SWM::new(peripherals.SWM);
+//! let     swm    = SWM::new(peripherals.SWM).split();
 //! let     gpio   = GPIO::new(peripherals.GPIO_PORT);
 //! let     usart0 = USART::new(peripherals.USART0);
 //!

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -133,8 +133,7 @@ pub struct USART<UsartX, State : InitState = init_state::Enabled> {
 impl<UsartX> USART<UsartX, init_state::Unknown>
     where UsartX: Peripheral,
 {
-    /// Create an instance of `USART`
-    pub fn new(usart: UsartX) -> Self {
+    pub(crate) fn new(usart: UsartX) -> Self {
         USART {
             usart : usart,
             _state: init_state::Unknown,

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -61,12 +61,8 @@
 //! // We also need to provide USART0's movable functions. Those need to be
 //! // unassigned, and since they are unassigned by default, we just need to
 //! // promise the API that we didn't change them.
-//! let u0_rxd = unsafe {
-//!     swm.movable_functions.u0_rxd.affirm_default_state()
-//! };
-//! let u0_txd = unsafe {
-//!     swm.movable_functions.u0_txd.affirm_default_state()
-//! };
+//! let u0_rxd = swm.movable_functions.u0_rxd;
+//! let u0_txd = swm.movable_functions.u0_txd;
 //!
 //! let (u0_rxd, _) = u0_rxd.assign(pio0_0.into_swm_pin(), &mut swm.handle);
 //! let (u0_txd, _) = u0_txd.assign(pio0_4.into_swm_pin(), &mut swm.handle);

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -59,11 +59,11 @@ pub struct WKT<State: InitState = init_state::Enabled> {
     _state: State,
 }
 
-impl WKT<init_state::Unknown> {
+impl WKT<init_state::Disabled> {
     pub(crate) fn new(wkt: raw::WKT) -> Self {
         WKT {
             wkt   : wkt,
-            _state: init_state::Unknown,
+            _state: init_state::Disabled,
         }
     }
 }

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -10,18 +10,12 @@
 //! extern crate nb;
 //!
 //! use lpc82x_hal::prelude::*;
-//! use lpc82x_hal::{
-//!     SYSCON,
-//!     WKT,
-//! };
+//! use lpc82x_hal::Peripherals;
 //!
-//! let mut peripherals = lpc82x::Peripherals::take().unwrap();
+//! let mut p = Peripherals::take().unwrap();
 //!
-//! let mut syscon = SYSCON::new(peripherals.SYSCON);
-//! let     timer  = WKT::new(peripherals.WKT);
-//!
-//! let mut syscon = syscon.split();
-//! let mut timer  = timer.enable(&mut syscon.handle);
+//! let mut syscon = p.syscon.split();
+//! let mut timer  = p.wkt.enable(&mut syscon.handle);
 //!
 //! // Start the timer at 750000. Sine the IRC-derived clock runs at 750 kHz,
 //! // this translates to a one second wait.

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -17,10 +17,11 @@
 //!
 //! let mut peripherals = lpc82x::Peripherals::take().unwrap();
 //!
-//! let mut syscon = SYSCON::new(&mut peripherals.SYSCON);
+//! let mut syscon = SYSCON::new(peripherals.SYSCON);
 //! let     timer  = WKT::new(peripherals.WKT);
 //!
-//! let mut timer = timer.enable(&mut syscon.handle);
+//! let mut syscon = syscon.split();
+//! let mut timer  = timer.enable(&mut syscon.handle);
 //!
 //! // Start the timer at 750000. Sine the IRC-derived clock runs at 750 kHz,
 //! // this translates to a one second wait.

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -60,8 +60,7 @@ pub struct WKT<State: InitState = init_state::Enabled> {
 }
 
 impl WKT<init_state::Unknown> {
-    /// Create an instance of `WKT`
-    pub fn new(wkt: raw::WKT) -> Self {
+    pub(crate) fn new(wkt: raw::WKT) -> Self {
         WKT {
             wkt   : wkt,
             _state: init_state::Unknown,

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -75,7 +75,7 @@ impl<State> WKT<State> where State: InitState {
     }
 }
 
-impl<State> WKT<State> where State: init_state::NotEnabled {
+impl WKT<init_state::Disabled> {
     /// Enable the self-wake-up timer
     ///
     /// This method is only available, if `WKT` is not already in the
@@ -99,7 +99,7 @@ impl<State> WKT<State> where State: init_state::NotEnabled {
     }
 }
 
-impl<State> WKT<State> where State: init_state::NotDisabled {
+impl WKT<init_state::Enabled> {
     /// Disable the self-wake-up timer
     ///
     /// This method is only available, if `WKT` is not already in the

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -75,6 +75,13 @@ impl WKT<init_state::Unknown> {
     }
 }
 
+impl<State> WKT<State> where State: InitState {
+    /// Return the raw peripheral
+    pub fn free(self) -> raw::WKT {
+        self.wkt
+    }
+}
+
 impl<State> WKT<State> where State: init_state::NotEnabled {
     /// Enable the self-wake-up timer
     ///


### PR DESCRIPTION
Radically simplifies state management, both internally and from an API perspective, by controlling the initialization of all peripherals, thereby making sure that the user couldn't have changed any peripherals (in safe code) before the API was initialized.

Close #69 
