### PR TITLE
Update `Peripherals`

### DIFF
--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -25,9 +25,9 @@ fn main() -> ! {
 
     // Other peripherals need to be initialized. Trying to use the API before
     // initializing them will actually lead to compile-time errors.
-    let mut swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
-    let mut wkt    = p.wkt.enable(&mut syscon.handle);
+    let mut swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
+    let mut wkt    = p.WKT.enable(&mut syscon.handle);
 
     // We're going to need a clock for sleeping. Let's use the IRC-derived clock
     // that runs at 750 kHz.
@@ -48,7 +48,7 @@ fn main() -> ! {
         .unassign(pio0_3, &mut swm.handle);
     let mut pio0_3 = pio0_3
         .into_unused_pin()
-        .into_gpio_pin(&p.gpio)
+        .into_gpio_pin(&p.GPIO)
         .into_output();
 
     // Let's already initialize the durations that we're going to sleep for

--- a/examples/i2c_vl53l0x.rs
+++ b/examples/i2c_vl53l0x.rs
@@ -34,9 +34,9 @@ entry!(main);
 fn main() -> ! {
     let mut p = Peripherals::take().unwrap();
 
-    let     i2c    = p.i2c0;
-    let mut swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let     i2c    = p.I2C0;
+    let mut swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     // Set baud rate to 115200 baud
     //
@@ -74,7 +74,7 @@ fn main() -> ! {
         &mut swm.handle,
     );
 
-    let serial = p.usart0
+    let serial = p.USART0
         .enable(
             &BaudRate::new(&syscon.uartfrg, 0),
             &mut syscon.handle,

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -31,9 +31,9 @@ fn main() -> ! {
     let mut cp = raw::CorePeripherals::take().unwrap();
     let mut p  = Peripherals::take().unwrap();
 
-    let mut pmu    = p.pmu.split();
-    let mut swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let mut pmu    = p.PMU.split();
+    let mut swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     // 115200 baud
     syscon.uartfrg.set_clkdiv(6);
@@ -50,7 +50,7 @@ fn main() -> ! {
         &mut swm.handle,
     );
 
-    let mut serial = p.usart0
+    let mut serial = p.USART0
         .enable(
             &baud_rate,
             &mut syscon.handle,
@@ -61,7 +61,7 @@ fn main() -> ! {
 
     let _ = pmu.low_power_clock.enable(&mut pmu.handle);
 
-    let mut wkt = p.wkt.enable(&mut syscon.handle);
+    let mut wkt = p.WKT.enable(&mut syscon.handle);
     wkt.select_clock::<LowPowerClock>();
 
     let five_seconds: u32 = 10_000 * 5;

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -15,10 +15,7 @@ use cortex_m::interrupt;
 use cortex_m_rt::ExceptionFrame;
 
 use lpc82x_hal::prelude::*;
-use lpc82x_hal::{
-    raw,
-    Peripherals,
-};
+use lpc82x_hal::Peripherals;
 use lpc82x_hal::pmu::LowPowerClock;
 use lpc82x_hal::raw::Interrupt;
 use lpc82x_hal::syscon::WktWakeup;
@@ -28,8 +25,7 @@ use lpc82x_hal::usart::BaudRate;
 entry!(main);
 
 fn main() -> ! {
-    let mut cp = raw::CorePeripherals::take().unwrap();
-    let mut p  = Peripherals::take().unwrap();
+    let mut p = Peripherals::take().unwrap();
 
     let mut pmu    = p.PMU.split();
     let mut swm    = p.SWM.split();
@@ -68,7 +64,9 @@ fn main() -> ! {
 
     // Need to re-assign some stuff that's needed inside the closure. Otherwise
     // it will try to move stuff that's still borrowed outside of it.
+    let mut nvic   = p.NVIC;
     let mut pmu    = pmu.handle;
+    let mut scb    = p.SCB;
     let mut syscon = syscon.handle;
 
     interrupt::free(|_| {
@@ -76,7 +74,7 @@ fn main() -> ! {
         // `interrupt::free` will allow the interrupt to wake up the system, if
         // it's sleeping. But the interrupt handler won't run, which means we
         // don't have to define one.
-        cp.NVIC.enable(Interrupt::WKT);
+        nvic.enable(Interrupt::WKT);
 
         // Busy Waiting
         serial.bwrite_all(b"5 seconds of busy waiting...\n")
@@ -96,9 +94,9 @@ fn main() -> ! {
         serial.bwrite_all(b"5 seconds of sleep mode...\n")
             .expect("UART write shouldn't fail");
         wkt.start(five_seconds);
-        cp.NVIC.clear_pending(Interrupt::WKT);
+        nvic.clear_pending(Interrupt::WKT);
         while let Err(nb::Error::WouldBlock) = wkt.wait() {
-            pmu.enter_sleep_mode(&mut cp.SCB);
+            pmu.enter_sleep_mode(&mut scb);
         }
 
         // Without this, the WKT interrupt won't wake up the system from
@@ -111,9 +109,9 @@ fn main() -> ! {
         block!(serial.flush())
             .expect("Flush shouldn't fail");
         wkt.start(five_seconds);
-        cp.NVIC.clear_pending(Interrupt::WKT);
+        nvic.clear_pending(Interrupt::WKT);
         while let Err(nb::Error::WouldBlock) = wkt.wait() {
-            unsafe { pmu.enter_deep_sleep_mode(&mut cp.SCB) };
+            unsafe { pmu.enter_deep_sleep_mode(&mut scb) };
         }
 
         // Power-down mode
@@ -122,9 +120,9 @@ fn main() -> ! {
         block!(serial.flush())
             .expect("Flush shouldn't fail");
         wkt.start(five_seconds);
-        cp.NVIC.clear_pending(Interrupt::WKT);
+        nvic.clear_pending(Interrupt::WKT);
         while let Err(nb::Error::WouldBlock) = wkt.wait() {
-            unsafe { pmu.enter_power_down_mode(&mut cp.SCB) };
+            unsafe { pmu.enter_power_down_mode(&mut scb) };
         }
 
         // A demonstration of deep power-down mode is currently missing from

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -20,8 +20,8 @@ entry!(main);
 fn main() -> ! {
     let mut p = Peripherals::take().unwrap();
 
-    let mut swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let mut swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     // Set baud rate to 115200 baud
     //
@@ -71,7 +71,7 @@ fn main() -> ! {
     // Initialize USART0. This should never fail, as the only reason `init`
     // returns a `Result::Err` is when the transmitter is busy, which it
     // shouldn't be right now.
-    let mut serial = p.usart0
+    let mut serial = p.USART0
         .enable(
             &baud_rate,
             &mut syscon.handle,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -16,10 +16,10 @@
 //!
 //! let mut p = Peripherals::take().unwrap();
 //!
-//! let swm = p.swm.split();
+//! let swm = p.SWM.split();
 //!
 //! let pio0_12 = swm.pins.pio0_12
-//!     .into_gpio_pin(&p.gpio)
+//!     .into_gpio_pin(&p.GPIO)
 //!     .into_output()
 //!     .set_high();
 //! ```
@@ -168,11 +168,11 @@ impl<'gpio, T, D> Pin<T, pin_state::Gpio<'gpio, D>>
     ///
     /// let p = Peripherals::take().unwrap();
     ///
-    /// let swm = p.swm.split();
+    /// let swm = p.SWM.split();
     ///
     /// // Transition pin into GPIO state, then set it to output
     /// let mut pin = swm.pins.pio0_12
-    ///     .into_gpio_pin(&p.gpio)
+    ///     .into_gpio_pin(&p.GPIO)
     ///     .into_output();
     ///
     /// // Output level can now be controlled

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -18,8 +18,8 @@
 //!
 //! let mut p = Peripherals::take().unwrap();
 //!
-//! let mut swm    = p.swm.split();
-//! let mut syscon = p.syscon.split();
+//! let mut swm    = p.SWM.split();
+//! let mut syscon = p.SYSCON.split();
 //!
 //! let (i2c0_sda, _) = swm.fixed_functions.i2c0_sda.assign(
 //!     swm.pins.pio0_11.into_swm_pin(),
@@ -30,7 +30,7 @@
 //!     &mut swm.handle,
 //! );
 //!
-//! let mut i2c = p.i2c0.enable(
+//! let mut i2c = p.I2C0.enable(
 //!     &mut syscon.handle,
 //!     i2c0_sda,
 //!     i2c0_scl,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,36 +269,37 @@ pub mod init_state {
 /// make sure you know what you're doing. In specific terms, this means you
 /// should be fully aware of what your code does, and whether that is a valid
 /// use of the hardware.
+#[allow(non_snake_case)]
 pub struct Peripherals {
     /// General-purpose I/O (GPIO)
     ///
     /// The GPIO peripheral is enabled by default. See user manual, section
     /// 5.6.14.
-    pub gpio: GPIO<init_state::Enabled>,
+    pub GPIO: GPIO<init_state::Enabled>,
 
     /// I2C0-bus interface
-    pub i2c0: I2C<init_state::Disabled>,
+    pub I2C0: I2C<init_state::Disabled>,
 
     /// Power Management Unit
-    pub pmu: PMU,
+    pub PMU: PMU,
 
     /// Switch matrix
-    pub swm: SWM,
+    pub SWM: SWM,
 
     /// System configuration
-    pub syscon: SYSCON,
+    pub SYSCON: SYSCON,
 
     /// USART0
-    pub usart0: USART<raw::USART0, init_state::Disabled>,
+    pub USART0: USART<raw::USART0, init_state::Disabled>,
 
     /// USART1
-    pub usart1: USART<raw::USART1, init_state::Disabled>,
+    pub USART1: USART<raw::USART1, init_state::Disabled>,
 
     /// USART2
-    pub usart2: USART<raw::USART2, init_state::Disabled>,
+    pub USART2: USART<raw::USART2, init_state::Disabled>,
 
     /// Self-wake-up timer (WKT)
-    pub wkt: WKT<init_state::Disabled>,
+    pub WKT: WKT<init_state::Disabled>,
 
 
     /// Analog-to-Digital Converter (ADC)
@@ -306,119 +307,119 @@ pub struct Peripherals {
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub adc: raw::ADC,
+    pub ADC: raw::ADC,
 
     /// Analog comparator
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub cmp: raw::CMP,
+    pub CMP: raw::CMP,
 
     /// CRC engine
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub crc: raw::CRC,
+    pub CRC: raw::CRC,
 
     /// DMA controller
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub dma: raw::DMA,
+    pub DMA: raw::DMA,
 
     /// DMA trigger mux
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub dmatrigmux: raw::DMATRIGMUX,
+    pub DMATRIGMUX: raw::DMATRIGMUX,
 
     /// Flash controller
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub flashctrl: raw::FLASHCTRL,
+    pub FLASHCTRL: raw::FLASHCTRL,
 
     /// I2C0-bus interface
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub i2c1: raw::I2C1,
+    pub I2C1: raw::I2C1,
 
     /// I2C0-bus interface
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub i2c2: raw::I2C2,
+    pub I2C2: raw::I2C2,
 
     /// I2C0-bus interface
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub i2c3: raw::I2C3,
+    pub I2C3: raw::I2C3,
 
     /// Input multiplexing
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub inputmux: raw::INPUTMUX,
+    pub INPUTMUX: raw::INPUTMUX,
 
     /// I/O configuration
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub iocon: raw::IOCON,
+    pub IOCON: raw::IOCON,
 
     /// Multi-Rate Timer (MRT)
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub mrt: raw::MRT,
+    pub MRT: raw::MRT,
 
     /// Pin interrupt and pattern match engine
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub pin_int: raw::PIN_INT,
+    pub PIN_INT: raw::PIN_INT,
 
     /// State Configurable Timer (SCT)
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub sct: raw::SCT,
+    pub SCT: raw::SCT,
 
     /// SPI0
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub spi0: raw::SPI0,
+    pub SPI0: raw::SPI0,
 
     /// SPI1
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub spi1: raw::SPI1,
+    pub SPI1: raw::SPI1,
 
     /// Windowed Watchdog Timer (WWDT)
     ///
     /// A HAL API for this peripheral has not been implemented yet. In the
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
-    pub wwdt: raw::WWDT,
+    pub WWDT: raw::WWDT,
 }
 
 impl Peripherals {
@@ -504,34 +505,34 @@ impl Peripherals {
     fn new(p: raw::Peripherals) -> Self {
         Peripherals {
             // HAL peripherals
-            gpio  : GPIO::new(p.GPIO_PORT),
-            i2c0  : I2C::new(p.I2C0),
-            pmu   : PMU::new(p.PMU),
-            swm   : SWM::new(p.SWM),
-            syscon: SYSCON::new(p.SYSCON),
-            usart0: USART::new(p.USART0),
-            usart1: USART::new(p.USART1),
-            usart2: USART::new(p.USART2),
-            wkt   : WKT::new(p.WKT),
+            GPIO  : GPIO::new(p.GPIO_PORT),
+            I2C0  : I2C::new(p.I2C0),
+            PMU   : PMU::new(p.PMU),
+            SWM   : SWM::new(p.SWM),
+            SYSCON: SYSCON::new(p.SYSCON),
+            USART0: USART::new(p.USART0),
+            USART1: USART::new(p.USART1),
+            USART2: USART::new(p.USART2),
+            WKT   : WKT::new(p.WKT),
 
             /// Raw peripherals
-            adc       : p.ADC,
-            cmp       : p.CMP,
-            crc       : p.CRC,
-            dma       : p.DMA,
-            dmatrigmux: p.DMATRIGMUX,
-            flashctrl : p.FLASHCTRL,
-            i2c1      : p.I2C1,
-            i2c2      : p.I2C2,
-            i2c3      : p.I2C3,
-            inputmux  : p.INPUTMUX,
-            iocon     : p.IOCON,
-            mrt       : p.MRT,
-            pin_int   : p.PIN_INT,
-            sct       : p.SCT,
-            spi0      : p.SPI0,
-            spi1      : p.SPI1,
-            wwdt      : p.WWDT,
+            ADC       : p.ADC,
+            CMP       : p.CMP,
+            CRC       : p.CRC,
+            DMA       : p.DMA,
+            DMATRIGMUX: p.DMATRIGMUX,
+            FLASHCTRL : p.FLASHCTRL,
+            I2C1      : p.I2C1,
+            I2C2      : p.I2C2,
+            I2C3      : p.I2C3,
+            INPUTMUX  : p.INPUTMUX,
+            IOCON     : p.IOCON,
+            MRT       : p.MRT,
+            PIN_INT   : p.PIN_INT,
+            SCT       : p.SCT,
+            SPI0      : p.SPI0,
+            SPI1      : p.SPI1,
+            WWDT      : p.WWDT,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,41 @@ pub struct Peripherals {
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
     pub WWDT: raw::WWDT,
+
+    /// CPUID
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub CPUID: raw::CPUID,
+
+    /// Debug Control Block (DCB)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub DCB: raw::DCB,
+
+    /// Data Watchpoint and Trace unit (DWT)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub DWT: raw::DWT,
+
+    /// Memory Protection Unit (MPU)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub MPU: raw::MPU,
+
+    /// Nested Vector Interrupt Controller (NVIC)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub NVIC: raw::NVIC,
+
+    /// System Control Block (SCB)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub SCB: raw::SCB,
+
+    /// SysTick: System Timer
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub SYST: raw::SYST,
 }
 
 impl Peripherals {
@@ -453,9 +488,10 @@ impl Peripherals {
     /// let p = Peripherals::take().unwrap();
     /// ```
     pub fn take() -> Option<Self> {
-        let p = raw::Peripherals::take()?;
-
-        Some(Self::new(p))
+        Some(Self::new(
+            raw::Peripherals::take()?,
+            raw::CorePeripherals::take()?,
+        ))
     }
 
     /// Steal the peripherals
@@ -499,10 +535,13 @@ impl Peripherals {
     /// Since there are no means within this API to forcibly change type state,
     /// you will need to resort to something like [`core::mem::transmute`].
     pub unsafe fn steal() -> Self {
-        Self::new(raw::Peripherals::steal())
+        Self::new(
+            raw::Peripherals::steal(),
+            raw::CorePeripherals::steal(),
+        )
     }
 
-    fn new(p: raw::Peripherals) -> Self {
+    fn new(p: raw::Peripherals, cp: raw::CorePeripherals) -> Self {
         Peripherals {
             // HAL peripherals
             GPIO  : GPIO::new(p.GPIO_PORT),
@@ -533,6 +572,15 @@ impl Peripherals {
             SPI0      : p.SPI0,
             SPI1      : p.SPI1,
             WWDT      : p.WWDT,
+
+            // Core peripherals
+            CPUID: cp.CPUID,
+            DCB  : cp.DCB,
+            DWT  : cp.DWT,
+            MPU  : cp.MPU,
+            NVIC : cp.NVIC,
+            SCB  : cp.SCB,
+            SYST : cp.SYST,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ impl Peripherals {
             USART2: USART::new(p.USART2),
             WKT   : WKT::new(p.WKT),
 
-            /// Raw peripherals
+            // Raw peripherals
             ADC       : p.ADC,
             CMP       : p.CMP,
             CRC       : p.CRC,

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -15,14 +15,13 @@
 //!     Peripherals,
 //! };
 //!
-//! let mut cp = raw::CorePeripherals::take().unwrap();
-//! let mut p  = Peripherals::take().unwrap();
+//! let mut p = Peripherals::take().unwrap();
 //!
 //! let mut pmu = p.PMU.split();
 //!
 //! // Enters sleep mode. Unless we set up some interrupts, we won't wake up
 //! // from this again.
-//! pmu.handle.enter_sleep_mode(&mut cp.SCB);
+//! pmu.handle.enter_sleep_mode(&mut p.SCB);
 //! ```
 //!
 //! Please refer to the [examples in the repository] for more example code.

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -18,7 +18,7 @@
 //! let mut cp = raw::CorePeripherals::take().unwrap();
 //! let mut p  = Peripherals::take().unwrap();
 //!
-//! let mut pmu = p.pmu.split();
+//! let mut pmu = p.PMU.split();
 //!
 //! // Enters sleep mode. Unless we set up some interrupts, we won't wake up
 //! // from this again.

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -68,8 +68,8 @@ pub trait Sleep<Clock> where Clock: clock::Enabled {
 ///
 /// let mut p = Peripherals::take().unwrap();
 ///
-/// let mut syscon = p.syscon.split();
-/// let mut wkt    = p.wkt.enable(&mut syscon.handle);
+/// let mut syscon = p.SYSCON.split();
+/// let mut wkt    = p.WKT.enable(&mut syscon.handle);
 ///
 /// let clock = syscon.irc_derived_clock;
 ///
@@ -141,9 +141,9 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// let mut cp = raw::CorePeripherals::take().unwrap();
 /// let mut p  = Peripherals::take().unwrap();
 ///
-/// let mut pmu    = p.pmu.split();
-/// let mut syscon = p.syscon.split();
-/// let mut wkt    = p.wkt.enable(&mut syscon.handle);
+/// let mut pmu    = p.PMU.split();
+/// let mut syscon = p.SYSCON.split();
+/// let mut wkt    = p.WKT.enable(&mut syscon.handle);
 ///
 /// let clock = syscon.irc_derived_clock;
 ///

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -138,8 +138,7 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// };
 /// use lpc82x_hal::clock::Ticks;
 ///
-/// let mut cp = raw::CorePeripherals::take().unwrap();
-/// let mut p  = Peripherals::take().unwrap();
+/// let mut p = Peripherals::take().unwrap();
 ///
 /// let mut pmu    = p.PMU.split();
 /// let mut syscon = p.SYSCON.split();
@@ -148,9 +147,9 @@ impl<'wkt, Clock> Sleep<Clock> for Busy<'wkt>
 /// let clock = syscon.irc_derived_clock;
 ///
 /// let mut sleep = sleep::Regular::prepare(
-///     &mut cp.NVIC,
+///     &mut p.NVIC,
 ///     &mut pmu.handle,
-///     &mut cp.SCB,
+///     &mut p.SCB,
 ///     &mut wkt,
 /// );
 ///

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -312,8 +312,7 @@ pins!(
 /// #
 /// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let     gpio = p.gpio;
-/// # let mut swm  = p.swm.split();
+/// # let mut swm = p.swm.split();
 /// #
 /// // Assign a function to a pin
 /// let (clkout, pio0_12) = swm.movable_functions.clkout.assign(
@@ -324,7 +323,7 @@ pins!(
 /// // As long as the function is assigned, we can't use the pin for
 /// // general-purpose I/O. Therefore the following method call would cause a
 /// // compile-time error.
-/// // let pio0_12 = pio0_12.into_gpio_pin(&gpio);
+/// // let pio0_12 = pio0_12.into_gpio_pin(&p.gpio);
 /// ```
 ///
 /// To use the pin in the above example for GPIO, we first have to unassign the
@@ -335,8 +334,7 @@ pins!(
 /// #
 /// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let     gpio = p.gpio;
-/// # let mut swm  = p.swm.split();
+/// # let mut swm = p.swm.split();
 /// #
 /// # let (clkout, pio0_12) = swm.movable_functions.clkout.assign(
 /// #     swm.pins.pio0_12.into_swm_pin(),
@@ -347,7 +345,7 @@ pins!(
 /// let pio0_12 = pio0_12.into_unused_pin();
 ///
 /// // Now we can transition the pin into the GPIO state.
-/// let pio0_12 = pio0_12.into_gpio_pin(&gpio);
+/// let pio0_12 = pio0_12.into_gpio_pin(&p.gpio);
 /// ```
 ///
 /// # General Purpose I/O

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -312,7 +312,7 @@ pins!(
 /// #
 /// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let mut swm = p.swm.split();
+/// # let mut swm = p.SWM.split();
 /// #
 /// // Assign a function to a pin
 /// let (clkout, pio0_12) = swm.movable_functions.clkout.assign(
@@ -323,7 +323,7 @@ pins!(
 /// // As long as the function is assigned, we can't use the pin for
 /// // general-purpose I/O. Therefore the following method call would cause a
 /// // compile-time error.
-/// // let pio0_12 = pio0_12.into_gpio_pin(&p.gpio);
+/// // let pio0_12 = pio0_12.into_gpio_pin(&p.GPIO);
 /// ```
 ///
 /// To use the pin in the above example for GPIO, we first have to unassign the
@@ -334,7 +334,7 @@ pins!(
 /// #
 /// # let mut p = Peripherals::take().unwrap();
 /// #
-/// # let mut swm = p.swm.split();
+/// # let mut swm = p.SWM.split();
 /// #
 /// # let (clkout, pio0_12) = swm.movable_functions.clkout.assign(
 /// #     swm.pins.pio0_12.into_swm_pin(),
@@ -345,7 +345,7 @@ pins!(
 /// let pio0_12 = pio0_12.into_unused_pin();
 ///
 /// // Now we can transition the pin into the GPIO state.
-/// let pio0_12 = pio0_12.into_gpio_pin(&p.gpio);
+/// let pio0_12 = pio0_12.into_gpio_pin(&p.GPIO);
 /// ```
 ///
 /// # General Purpose I/O
@@ -360,12 +360,12 @@ pins!(
 ///
 /// let mut p = Peripherals::take().unwrap();
 ///
-/// let mut swm = p.swm.split();
+/// let mut swm = p.SWM.split();
 ///
 /// // The pin takes a shared reference to `GPIO`, which it keeps around as long
 /// // as the pin is in the GPIO state. This ensures the GPIO peripheral can't
 /// // be disabled while we're still using the pin for GPIO.
-/// let pin = swm.pins.pio0_12.into_gpio_pin(&p.gpio);
+/// let pin = swm.pins.pio0_12.into_gpio_pin(&p.GPIO);
 /// ```
 ///
 /// Now `pin` is in the GPIO state. The GPIO state has the following sub-states:
@@ -385,10 +385,10 @@ pins!(
 /// #
 /// # let p = Peripherals::take().unwrap();
 /// #
-/// # let mut swm = p.swm.split();
+/// # let mut swm = p.SWM.split();
 /// #
 /// # let pin = swm.pins.pio0_12
-/// #     .into_gpio_pin(&p.gpio);
+/// #     .into_gpio_pin(&p.GPIO);
 /// #
 /// use lpc82x_hal::prelude::*;
 ///
@@ -418,7 +418,7 @@ pins!(
 /// #
 /// # let p = Peripherals::take().unwrap();
 /// #
-/// # let swm = p.swm.split();
+/// # let swm = p.SWM.split();
 /// #
 /// let pin = swm.pins.pio0_12
 ///     .into_swm_pin();
@@ -450,7 +450,7 @@ pins!(
 ///
 /// let p = Peripherals::take().unwrap();
 ///
-/// let mut swm = p.swm.split();
+/// let mut swm = p.SWM.split();
 ///
 /// // Transition pin into ADC state
 /// let (adc_2, pio0_14) = swm.fixed_functions.adc_2.assign(
@@ -498,10 +498,10 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     ///
     /// let p = Peripherals::take().unwrap();
     ///
-    /// let swm = p.swm.split();
+    /// let swm = p.SWM.split();
     ///
     /// let pin = swm.pins.pio0_12
-    ///     .into_gpio_pin(&p.gpio);
+    ///     .into_gpio_pin(&p.GPIO);
     ///
     /// // `pin` is now available for general-purpose I/O
     /// ```
@@ -542,7 +542,7 @@ impl<T> Pin<T, pin_state::Unused> where T: PinTrait {
     ///
     /// let p = Peripherals::take().unwrap();
     ///
-    /// let swm = p.swm.split();
+    /// let swm = p.SWM.split();
     ///
     /// let pin = swm.pins.pio0_12
     ///     .into_swm_pin();
@@ -798,7 +798,7 @@ impl<T> Function<T, state::Unassigned> {
     ///
     /// let p = Peripherals::take().unwrap();
     ///
-    /// let mut swm = p.swm.split();
+    /// let mut swm = p.SWM.split();
     ///
     /// // Assign output function to a pin
     /// let (u0_txd, pio0_0) = swm.movable_functions.u0_txd.assign(
@@ -868,7 +868,7 @@ impl<T, P> Function<T, state::Assigned<P>> {
     /// #
     /// # let p = Peripherals::take().unwrap();
     /// #
-    /// # let mut swm = p.swm.split();
+    /// # let mut swm = p.SWM.split();
     /// #
     /// # // Assign output function to a pin
     /// # let (u0_txd, pio0_0) = swm.movable_functions.u0_txd.assign(

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -17,8 +17,8 @@
 //!
 //! let mut p = Peripherals::take().unwrap();
 //!
-//! let mut syscon = p.syscon.split();
-//! let mut swm    = p.swm.split();
+//! let mut syscon = p.SYSCON.split();
+//! let mut swm    = p.SWM.split();
 //!
 //! // Set baud rate to 115200 baud
 //! // Please refer to the USART example in the repository for a full
@@ -40,7 +40,7 @@
 //! // Initialize USART0. This should never fail, as the only reason `init`
 //! // returns a `Result::Err` is when the transmitter is busy, which it
 //! // shouldn't be right now.
-//! let mut serial = p.usart0
+//! let mut serial = p.USART0
 //!     .enable(
 //!         &baud_rate,
 //!         &mut syscon.handle,

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -15,8 +15,8 @@
 //!
 //! let mut p = Peripherals::take().unwrap();
 //!
-//! let mut syscon = p.syscon.split();
-//! let mut timer  = p.wkt.enable(&mut syscon.handle);
+//! let mut syscon = p.SYSCON.split();
+//! let mut timer  = p.WKT.enable(&mut syscon.handle);
 //!
 //! // Start the timer at 750000. Sine the IRC-derived clock runs at 750 kHz,
 //! // this translates to a one second wait.

--- a/tests/compile-fail/swm/assign-function-to-multiple-pins.rs
+++ b/tests/compile-fail/swm/assign-function-to-multiple-pins.rs
@@ -12,8 +12,8 @@ use lpc82x_hal::swm::{
 fn main() {
     let mut p = Peripherals::take().unwrap();
 
-    let     swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let     swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     let pio0_0: Pin<_, pin_state::Unused> = swm.pins.pio0_0;
     let pio0_1: Pin<_, pin_state::Unused> = swm.pins.pio0_1;

--- a/tests/compile-fail/swm/assign-multiple-output-functions.rs
+++ b/tests/compile-fail/swm/assign-multiple-output-functions.rs
@@ -12,8 +12,8 @@ use lpc82x_hal::swm::{
 fn main() {
     let mut p = Peripherals::take().unwrap();
 
-    let     swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let     swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     let pio0_0: Pin<_, pin_state::Unused> = swm.pins.pio0_0;
 

--- a/tests/compile-fail/swm/unassign-function-from-wrong-pin.rs
+++ b/tests/compile-fail/swm/unassign-function-from-wrong-pin.rs
@@ -12,8 +12,8 @@ use lpc82x_hal::swm::{
 fn main() {
     let mut p = Peripherals::take().unwrap();
 
-    let     swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let     swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     let pio0_0: Pin<_, pin_state::Unused> = swm.pins.pio0_0;
     let pio0_1: Pin<_, pin_state::Unused> = swm.pins.pio0_1;

--- a/tests/compile-fail/swm/unassign-unassigned-input-function.rs
+++ b/tests/compile-fail/swm/unassign-unassigned-input-function.rs
@@ -12,8 +12,8 @@ use lpc82x_hal::swm::{
 fn main() {
     let mut p = Peripherals::take().unwrap();
 
-    let     swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let     swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     let pio0_0: Pin<_, pin_state::Unused> = swm.pins.pio0_0;
 

--- a/tests/compile-fail/swm/unassign-unassigned-output-function.rs
+++ b/tests/compile-fail/swm/unassign-unassigned-output-function.rs
@@ -12,8 +12,8 @@ use lpc82x_hal::swm::{
 fn main() {
     let mut p = Peripherals::take().unwrap();
 
-    let     swm    = p.swm.split();
-    let mut syscon = p.syscon.split();
+    let     swm    = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
 
     let pio0_0: Pin<_, pin_state::Unused> = swm.pins.pio0_0;
 


### PR DESCRIPTION
Renames the field of `Peripherals` to be in line with `raw::Peripherals` and `raw::CorePeripherals`. Adds core peripherals to `Peripherals`.