### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,7 @@ $ git checkout -b release-x.y.z
 $ git push -u origin release-x.y.z
 ```
 
-3. Update changelog (make manual changes as required)
-```
-$ clog --from-latest-tag -o CHANGELOG.md --major|--minor|--patch
-```
+3. Update changelog
 
 4. Update versions in README.md, if version bump is major or minor
 


### PR DESCRIPTION
I've removed GitCop from this repository, which means Clog can no longer
be used to generate the changelog.

It turned out that Clog wasn't very helpful for me, while GitCop
regularly caused problems for contributors (in other projects). It just
wasn't worth it.