### PR TITLE
Take unshifted I2C addresses.

### DIFF
--- a/examples/i2c_eeprom.rs
+++ b/examples/i2c_eeprom.rs
@@ -93,7 +93,7 @@ fn main() -> ! {
 
     // Address of the eeprom
     // ADJUST THIS
-    let address = 0b1010_0000;
+    let address = 0b101_0000;
 
     serial
         .bwrite_all(b"Writing data...\n")

--- a/examples/i2c_master_slave.rs
+++ b/examples/i2c_master_slave.rs
@@ -10,7 +10,7 @@ use lpc8xx_hal::{
 };
 use rtt_target::rprintln;
 
-const ADDRESS: u8 = 0x48;
+const ADDRESS: u8 = 0x24;
 
 #[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {

--- a/examples/i2c_master_slave_dma.rs
+++ b/examples/i2c_master_slave_dma.rs
@@ -10,7 +10,7 @@ use lpc8xx_hal::{
 };
 use rtt_target::rprintln;
 
-const ADDRESS: u8 = 0x48;
+const ADDRESS: u8 = 0x24;
 
 #[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {

--- a/examples/i2c_vl53l0x.rs
+++ b/examples/i2c_vl53l0x.rs
@@ -17,6 +17,8 @@ use core::fmt::Write;
 
 use lpc8xx_hal::{cortex_m_rt::entry, i2c, prelude::*, usart, Peripherals};
 
+const ADDRESS: u8 = 0x29;
+
 #[entry]
 fn main() -> ! {
     rtt_target::rtt_init_print!();
@@ -95,7 +97,7 @@ fn main() -> ! {
 
     // Write index of reference register
     i2c.master
-        .write(0x52, &[0xC0])
+        .write(ADDRESS, &[0xC0])
         .expect("Failed to write data");
 
     serial
@@ -105,7 +107,7 @@ fn main() -> ! {
     // Read value from reference register
     let mut buffer = [0u8; 1];
     i2c.master
-        .read(0x52, &mut buffer)
+        .read(ADDRESS, &mut buffer)
         .expect("Failed to read data");
 
     write!(serial, "{:#X}\n", buffer[0]).expect("Write should never fail");

--- a/src/i2c/error.rs
+++ b/src/i2c/error.rs
@@ -2,6 +2,7 @@ use super::{master, Instance};
 
 /// I2C error
 #[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// Event Timeout
     ///
@@ -39,6 +40,11 @@ pub enum Error {
         /// represents an invalid bit pattern in the MSTSTATE field.
         actual: Result<master::State, u8>,
     },
+
+    /// An unencodable address was specified.
+    ///
+    /// Currently, only seven-bit addressing is implemented.
+    AddressOutOfRange,
 
     /// While in slave mode, an unknown state was detected
     UnknownSlaveState(u8),

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -120,13 +120,17 @@ where
     }
 
     fn start_operation(&mut self, address: u8, rw: Rw) -> Result<(), Error> {
+        if address > 0b111_1111 {
+            return Err(Error::AddressOutOfRange);
+        }
+
         self.wait_for_state(State::Idle)?;
 
         // Write address
-        let address = address & 0xfe | rw as u8;
+        let address_rw = (address << 1) | rw as u8;
         self.mstdat.write(|w| unsafe {
             // Sound, as all 8-bit values are accepted here.
-            w.data().bits(address)
+            w.data().bits(address_rw)
         });
 
         // Start operation

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -122,7 +122,7 @@ where
     pub fn address(&self) -> Result<u8, Error> {
         Error::read::<I>()?;
 
-        let address = self.slvdat.read().data().bits();
+        let address = self.slvdat.read().data().bits() >> 1;
         Ok(address)
     }
 


### PR DESCRIPTION
This brings `lpc8xx-hal::i2c` in line with (my understanding of) the [`embedded_hal::i2c::Write`](https://docs.rs/embedded-hal/0.2.4/embedded_hal/blocking/i2c/index.html) trait, which seems to require plain seven-bit addresses.

I tested this with the [`ssd1306` (OLED display driver) crate](https://crates.io/crates/ssd1306), which defaults to the address used by the hardware. With this patch, the two crates work together without issue.

I also updated the examples to keep the actual address unchanged, but I don't have any of the devices they use. Similarly, I don't have a convenient way to test the slave mode.